### PR TITLE
use libusb instead of pciescreamer driver

### DIFF
--- a/leechcore/Makefile
+++ b/leechcore/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS=-I. -D LINUX -shared -fPIC -fvisibility=hidden -pthread `pkg-config libusb-1.0 --libs --cflags`
 DEPS = leechcore.h
-OBJ = oscompatibility.o leechcore.o util.o memmap.o device_file.o device_fpga.o device_hvsavedstate.o device_pmem.o device_rawtcp.o device_sp605tcp.o device_tmd.o device_usb3380.o tlp.o leechrpcclient.o
+OBJ = fpga_libusb.o oscompatibility.o leechcore.o util.o memmap.o device_file.o device_fpga.o device_hvsavedstate.o device_pmem.o device_rawtcp.o device_sp605tcp.o device_tmd.o device_usb3380.o tlp.o leechrpcclient.o
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS)

--- a/leechcore/fpga_libusb.c
+++ b/leechcore/fpga_libusb.c
@@ -1,0 +1,301 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <libusb.h>
+
+#include "fpga_libusb.h"
+
+static libusb_context *usb_ctx = NULL;
+static libusb_device_handle *device_handle = NULL;
+
+int ftdi_GetChipConfiguration(libusb_device_handle *device, struct FT_60XCONFIGURATION *config) {
+    int err;
+
+    err = libusb_control_transfer(device,
+        LIBUSB_RECIPIENT_DEVICE | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_IN,
+        0xCF, // proprietary stuffz
+        1, // value
+        0, //index
+        (void*) config,
+        sizeof(struct FT_60XCONFIGURATION),
+        1000
+    );
+
+    return err;
+}
+
+int ftdi_SetChipConfiguration(libusb_device_handle *device, struct FT_60XCONFIGURATION *config) {
+    int err;
+
+    err = libusb_control_transfer(device,
+        LIBUSB_RECIPIENT_DEVICE | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT,
+        0xCF, // proprietary stuffz
+        0, // value
+        0, //index
+        (void*) config,
+        sizeof(struct FT_60XCONFIGURATION),
+        1000
+    );
+
+    return err;
+}
+
+int ftdi_SendCmdRead(libusb_device_handle *device, int size)
+{
+    int transferred = 0;
+    struct ft60x_ctrlreq ctrlreq;
+
+    memset(&ctrlreq, 0, sizeof(ctrlreq));
+    ctrlreq.idx++;
+    ctrlreq.pipe = FTDI_ENDPOINT_IN;
+    ctrlreq.cmd = 1; // read cmd.
+    ctrlreq.len = size;
+
+    return libusb_bulk_transfer(device, FTDI_ENDPOINT_SESSION_OUT, (void*) &ctrlreq, sizeof(struct ft60x_ctrlreq), &transferred, 1000);
+}
+
+int fpga_get_chip_configuration(void *config) {
+    int rc = 0;
+    int err;
+    
+    err = ftdi_GetChipConfiguration(device_handle, config);
+
+    if(err != sizeof(struct FT_60XCONFIGURATION)) {
+        printf("[-] cannot get chip config: %s\n", libusb_strerror(err));
+        rc = -1;
+    }
+
+    return rc;
+}
+
+int fpga_set_chip_configuration(void *config) {
+    int rc = 0;
+
+    if(ftdi_SetChipConfiguration(device_handle, config) != LIBUSB_SUCCESS) {
+        rc = -1;
+    }
+
+    return rc;
+}
+
+int fpga_open(void)
+{
+    int rc = 0;
+    ssize_t device_count;
+    libusb_device **device_list;
+    libusb_device *device;
+    struct libusb_device_descriptor desc;
+    int err;
+    int i;
+    int found;
+    struct FT_60XCONFIGURATION chip_configuration;
+    unsigned char string[255] = {0};
+    char description[255] = {0};
+
+    if(libusb_init(&usb_ctx)) {
+        rc = -1;
+        goto out;
+    }
+
+    device_count = libusb_get_device_list(usb_ctx, &device_list);
+    if(device_count < 0) {
+        printf("[-] Cannot get device list: %s\n", libusb_strerror(device_count));
+        rc = -1;
+        goto out;
+    }
+
+    found = 0;
+    for(i=0; i<device_count; i++) {
+        device = device_list[i];
+
+        err = libusb_get_device_descriptor(device, &desc);
+        if(err != 0) {
+            printf("[-] Cannot get device descriptor: %s\n", libusb_strerror(err));
+            rc = -1;
+            goto out_free;
+        }
+
+        if(desc.idVendor == FTDI_VENDOR_ID && desc.idProduct == FTDI_FT60X_PRODUCT_ID) {
+            printf("[+] using FTDI device: %04x:%04x (bus %d, device %d)\n", 
+                desc.idVendor,
+                desc.idProduct,
+                libusb_get_bus_number(device),
+                libusb_get_device_address(device));
+            found = 1;
+            break;
+        }
+
+    }
+
+    if(!found) {
+        rc = -1;
+        goto out_free;
+    }
+
+    err = libusb_open(device, &device_handle);
+    if(err != 0) {
+        printf("[-] Cannot get device: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+    err = libusb_reset_device(device_handle);
+    if(err != 0) {
+        printf("[-] Cannot reset device: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+    err = libusb_get_string_descriptor_ascii(device_handle, desc.iManufacturer, string, sizeof(string));
+    if(err > 0) {
+        snprintf(description, sizeof(description), "%s - ", string);
+    } else {
+        snprintf(description, sizeof(description), "%04X - ", desc.idVendor);
+    }
+
+    err = libusb_get_string_descriptor_ascii(device_handle, desc.iProduct, string, sizeof(string));
+    if(err > 0) {
+        snprintf(description + strlen(description), sizeof(description), "%s", string);
+    } else {
+        snprintf(description + strlen(description), sizeof(description), "%04X", desc.idProduct);
+    }
+
+    err = libusb_get_string_descriptor_ascii(device_handle, desc.iSerialNumber, string, sizeof(string));
+    if(err > 0) {
+        snprintf(description + strlen(description), sizeof(description), " - serialNumber %s", string);
+    }
+
+    printf("[+] %s\n", description);
+
+    err = ftdi_GetChipConfiguration(device_handle, &chip_configuration);
+    if(err != sizeof(chip_configuration)) {
+        printf("[-] Cannot get chio configuration: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+
+    if( chip_configuration.FIFOMode != CONFIGURATION_FIFO_MODE_245 ||
+        chip_configuration.ChannelConfig != CONFIGURATION_CHANNEL_CONFIG_1 ||
+        chip_configuration.OptionalFeatureSupport != CONFIGURATION_OPTIONAL_FEATURE_DISABLEALL
+      ) {
+        printf("[!] Bad FTDI configuration... setting chip config to fifo 245 && 1 channel, no feature support\n");
+
+        chip_configuration.FIFOMode = CONFIGURATION_FIFO_MODE_245;
+        chip_configuration.ChannelConfig = CONFIGURATION_CHANNEL_CONFIG_1;
+        chip_configuration.OptionalFeatureSupport = CONFIGURATION_OPTIONAL_FEATURE_DISABLEALL;
+
+        err = ftdi_SetChipConfiguration(device_handle, &chip_configuration);
+        if(err != sizeof(chip_configuration)) {
+            printf("[-] Cannot set chip configuration: %s\n", libusb_strerror(err));
+            rc = -1;
+            goto out_free;
+        }
+
+    }
+
+    err = libusb_kernel_driver_active(device_handle, FTDI_COMMUNICATION_INTERFACE);
+    if(err < 0) {
+        printf("[-] Cannot get kernel driver status for FTDI_COMMUNICATION_INTERFACE: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+    if(err) {
+        printf("[-] driver is active on FTDI_COMMUNICATION_INTERFACE = %d\n", err);
+        rc = -1;
+        goto out_free;
+    }
+
+    err = libusb_kernel_driver_active(device_handle, FTDI_DATA_INTERFACE);
+    if(err < 0) {
+        printf("[-] Cannot get kernel driver status for FTDI_DATA_INTERFACE: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+    if(err) {
+        printf("[-] driver is active on FTDI_DATA_INTERFACE = %d\n", err);
+        rc = -1;
+        goto out_free;
+    }
+
+    err = libusb_claim_interface(device_handle, FTDI_COMMUNICATION_INTERFACE);
+    if(err != 0) {
+        printf("[-] Cannot claim interface FTDI_COMMUNICATION_INTERFACE: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+    err = libusb_claim_interface(device_handle, FTDI_DATA_INTERFACE);
+    if(err != 0) {
+        printf("[-] Cannot claim interface FTDI_DATA_INTERFACE: %s\n", libusb_strerror(err));
+        rc = -1;
+        goto out_free;
+    }
+
+out_free:
+    libusb_free_device_list(device_list, 1);
+
+out:
+    
+    return rc;
+}
+
+int fpga_close(void)
+{
+    libusb_close(device_handle);
+    libusb_exit(usb_ctx);
+
+    device_handle = NULL;
+    usb_ctx = NULL;
+
+    return 0;
+}
+
+int fpga_read(void *data, int size, int *transferred)
+{
+    int err;
+
+    err = ftdi_SendCmdRead(device_handle, size);
+    if(err) {
+        printf("[-] cannot send CmdRead ftdi: %s", libusb_strerror(err));
+        return -1;
+    }
+
+    *transferred = 0;
+    err = libusb_bulk_transfer(device_handle, FTDI_ENDPOINT_IN, data, size, transferred, 0);
+    if(err < 0) {
+        printf("[-] bulk transfer error: %s", libusb_strerror(err));
+        return -1;
+    }
+
+    // Commented out because in that case, size is a max size.
+    // Caller should check the transferred value
+    // if(*transferred != size) {
+    //  rc = PCILEECH_ERROR_TRANSFER_NOT_COMPLETE;
+    //  goto end;
+    // }
+
+    return 0;
+}
+
+int fpga_write(void *data, int size, int *transferred)
+{
+    int err;
+    
+    *transferred = 0;
+    err = libusb_bulk_transfer(device_handle, FTDI_ENDPOINT_OUT, data, size, transferred, 1000);
+
+    if(err < 0) {
+        printf("[-] bulk transfer error: %s", libusb_strerror(err));
+        return -1;
+    }
+
+    if(*transferred != size) {
+        printf("[-] only %d bytes transferred\n", *transferred);
+        return -1;
+    }
+
+    return 0;
+}

--- a/leechcore/fpga_libusb.c
+++ b/leechcore/fpga_libusb.c
@@ -1,3 +1,10 @@
+// fpga_libusb.c :
+//     Code to directly communicate with the FT601 without using a kernel driver. Works with :
+//     - Xilinx SP605 dev board flashed with PCILeech bitstream and FTDI UMFT601X-B addon-board.
+//     - Xilinx AC701 dev board flashed with PCILeech bitstream and FTDI UMFT601X-B addon-board.
+//     - PCIeScreamer board flashed with PCILeech bitstream.
+//
+// Contribution by Jérémie Boutoille from Synacktiv - www.synacktiv.com
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/leechcore/fpga_libusb.h
+++ b/leechcore/fpga_libusb.h
@@ -1,0 +1,115 @@
+#ifndef __FPGA_LIBUSB_H__
+#define __FPGA_LIBUSB_H__
+
+int fpga_open(void);
+int fpga_close(void);
+int fpga_get_chip_configuration(void *config);
+int fpga_set_chip_configuration(void *config);
+int fpga_read(void *data, int size, int *transferred);
+int fpga_write(void *data, int size, int *transferred);
+
+/*
+The FTDI device has 2 interfaces, with one or multiple endpoints, depending the configuration.
+Interface 0:
+	endpoint 0x01 : OUT BULK endpoint for Session List commands
+	endpoint 0x81: IN INTERRUPT endpoint for Notification List commands
+Interface 1:
+	endpoint 0x02-0x05: OUT BULK endpoint for application write access
+	endpoint 0x82-0x85: IN BULK endpoint for application read access
+
+We only use interface 1 and 0x02 0x82 endspoints
+*/
+
+#define FTDI_VENDOR_ID 0x0403
+#define FTDI_FT60X_PRODUCT_ID 0x601f
+#define FTDI_COMMUNICATION_INTERFACE 0x00
+#define FTDI_DATA_INTERFACE 0x01
+#define FTDI_ENDPOINT_SESSION_OUT 0x01
+#define FTDI_ENDPOINT_OUT 0x02
+#define FTDI_ENDPOINT_IN 0x82
+
+// from pcie_screamer driver
+
+struct ft60x_ctrlreq {
+	unsigned int idx;
+	unsigned char pipe;
+	unsigned char cmd;
+	unsigned char unk1;
+	unsigned char unk2;
+	unsigned int len;
+	unsigned int unk4;
+	unsigned int unk5;
+} __attribute__ ((packed));
+
+// from ft3xx.h
+
+//
+// Chip configuration - FIFO Mode
+//
+enum CONFIGURATION_FIFO_MODE {
+	CONFIGURATION_FIFO_MODE_245,
+	CONFIGURATION_FIFO_MODE_600,
+	CONFIGURATION_FIFO_MODE_COUNT,
+};
+
+//
+// Chip configuration - Channel Configuration
+//
+enum CONFIGURATION_CHANNEL_CONFIG {
+	CONFIGURATION_CHANNEL_CONFIG_4,
+	CONFIGURATION_CHANNEL_CONFIG_2,
+	CONFIGURATION_CHANNEL_CONFIG_1,
+	CONFIGURATION_CHANNEL_CONFIG_1_OUTPIPE,
+	CONFIGURATION_CHANNEL_CONFIG_1_INPIPE,
+	CONFIGURATION_CHANNEL_CONFIG_COUNT,
+};
+
+//
+// Chip configuration - Optional Feature Support
+//
+enum CONFIGURATION_OPTIONAL_FEATURE_SUPPORT {
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLEALL = 0,
+	CONFIGURATION_OPTIONAL_FEATURE_ENABLEBATTERYCHARGING = 1,
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLECANCELSESSIONUNDERRUN = 2,
+	CONFIGURATION_OPTIONAL_FEATURE_ENABLENOTIFICATIONMESSAGE_INCH1 = 4,
+	CONFIGURATION_OPTIONAL_FEATURE_ENABLENOTIFICATIONMESSAGE_INCH2 = 8,
+	CONFIGURATION_OPTIONAL_FEATURE_ENABLENOTIFICATIONMESSAGE_INCH3 = 0x10,
+	CONFIGURATION_OPTIONAL_FEATURE_ENABLENOTIFICATIONMESSAGE_INCH4 = 0x20,
+	CONFIGURATION_OPTIONAL_FEATURE_ENABLENOTIFICATIONMESSAGE_INCHALL = 0x3C,
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLEUNDERRUN_INCH1   = (0x1 << 6),
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLEUNDERRUN_INCH2   = (0x1 << 7),
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLEUNDERRUN_INCH3   = (0x1 << 8),
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLEUNDERRUN_INCH4   = (0x1 << 9),
+	CONFIGURATION_OPTIONAL_FEATURE_DISABLEUNDERRUN_INCHALL = (0xF << 6),
+};
+
+struct FT_60XCONFIGURATION {
+	// Device Descriptor
+	short       VendorID;
+	short       ProductID;
+
+	// String Descriptors
+	char        StringDescriptors[128];
+
+	// Configuration Descriptor
+	char        Reserved;
+	char        PowerAttributes;
+	short       PowerConsumption;
+
+	// Data Transfer Configuration
+	char        reserved;
+	char        FIFOClock;
+	char        FIFOMode;
+	char        ChannelConfig;
+
+	// Optional Feature Support
+	short       OptionalFeatureSupport;
+	char        BatteryChargingGPIOConfig;
+	char        FlashEEPROMDetection;      // Read-only
+
+	// MSIO and GPIO Configuration
+	unsigned int        MSIO_Control;
+	unsigned int        GPIO_Control;
+};
+
+#endif

--- a/leechcore/fpga_libusb.h
+++ b/leechcore/fpga_libusb.h
@@ -1,3 +1,10 @@
+// fpga_libusb.c :
+//     Code to directly communicate with the FT601 without using a kernel driver. Works with :
+//     - Xilinx SP605 dev board flashed with PCILeech bitstream and FTDI UMFT601X-B addon-board.
+//     - Xilinx AC701 dev board flashed with PCILeech bitstream and FTDI UMFT601X-B addon-board.
+//     - PCIeScreamer board flashed with PCILeech bitstream.
+//
+// Contribution by Jérémie Boutoille from Synacktiv - www.synacktiv.com
 #ifndef __FPGA_LIBUSB_H__
 #define __FPGA_LIBUSB_H__
 


### PR DESCRIPTION

Because the FTDI library is quite buggy on Linux, pcileech use the pciescreamer driver to speak with the FT601 (https://github.com/enjoy-digital/pcie_screamer/tree/master/drivers/ft60x). This requires to build a kernel module, load it as root, and use udev rules... 

This patch introduce code to directly communicate with the FT601 without using a kernel driver, through libusb and out of the box. The code is largely based on pciescreamer code and reverse engineering of the FTDI library.

It has only been tested with a SP605.



```
$ ./pcileech probe

[+] using FTDI device: 0403:601f (bus 2, device 9)
[+] FTDI - FTDI SuperSpeed-FIFO Bridge - serialNumber 000000000001
 Memory Map:                                     
 START              END               #PAGES   
 fffffffffffff000 - 000000000009efff  000000a0   
 00000000000bf000 - 000000008affefff  0008af40   
 00000000a09ff000 - 00000000a0a3ffff  00000041   
 00000000fffff000 - 000000016fdfefff  0006fe00              
                                                                              
 Current Action: Probing Memory                                               
 Access Mode:    Normal                                                       
 Progress:       5886 / 5886 (100%)                      
 Speed:          735 MB/s                                
 Address:        0x000000016FDFF000                      
 Pages read:     1027617 / 1506816 (68%)           
 Pages failed:   479199 (31%)                  
Memory Probe: Completed.
```

Cheers !
