### PR TITLE
Python binding improvements

### DIFF
--- a/leechcorepyc/leechcore.h
+++ b/leechcorepyc/leechcore.h
@@ -180,7 +180,7 @@ typedef char                                CHAR, *PCHAR, *PSTR, *LPSTR;
 typedef const CHAR                          *LPCSTR;
 typedef uint16_t                            WORD, *PWORD, USHORT, *PUSHORT;
 typedef uint32_t                            DWORD, *PDWORD;
-typedef long long unsigned int              QWORD, *PQWORD, ULONG64, *PULONG64;
+typedef long long unsigned int              QWORD, *PQWORD, ULONG64, *PULONG64, *ULONG_PTR, SIZE_T;
 #define MAX_PATH                            260
 #define DLLEXPORT                           __attribute__((visibility("default")))
 #define _In_

--- a/leechcorepyc/leechcorepyc.c
+++ b/leechcorepyc/leechcorepyc.c
@@ -138,7 +138,6 @@ static PyObject*
 LEECHCOREPYC_Read(PyObject *self, PyObject *args)
 {
     PyObject *pyBytes;
-    BOOL result;
     DWORD cb, cbRead = 0, flags = 0;
     ULONG64 pa;
     PBYTE pb;
@@ -147,9 +146,9 @@ LEECHCOREPYC_Read(PyObject *self, PyObject *args)
     pb = LocalAlloc(0, cb);
     if(!pb) { return PyErr_NoMemory(); }
     Py_BEGIN_ALLOW_THREADS;
-    result = LeechCore_ReadEx(pa, pb, cb, flags, NULL);
+    cbRead = LeechCore_ReadEx(pa, pb, cb, flags, NULL);
     Py_END_ALLOW_THREADS;
-    if(!result) {
+    if(!cbRead) {
         LocalFree(pb);
         return PyErr_Format(PyExc_RuntimeError, "LEECHCOREPYC_Read: Failed.");
     }

--- a/leechcorepyc/leechcorepyc.c
+++ b/leechcorepyc/leechcorepyc.c
@@ -6,13 +6,26 @@
 #define Py_LIMITED_API 0x03060000
 #ifdef _DEBUG
 #undef _DEBUG
-#include <python.h>
+#include <Python.h>
 #define _DEBUG
 #else
-#include <python.h>
+#include <Python.h>
 #endif
+
+#ifdef _WIN32
 #include <Windows.h>
+#endif
 #include "leechcore.h"
+
+#ifdef LINUX
+#define _TRUNCATE -1
+
+error_t strncpy_s(char *restrict dest, size_t destsz,
+                  const char *restrict src, size_t count) {
+	if (count == _TRUNCATE) count = destsz - 1;
+	strncpy(dest, src, count);
+}
+#endif
 
 inline int PyDict_SetItemString_DECREF(PyObject *dp, const char *key, PyObject *item)
 {
@@ -256,7 +269,7 @@ static PyModuleDef LEECHCOREPYC_Module = {
     NULL, NULL, NULL, NULL
 };
 
-__declspec(dllexport) PyObject* PyInit_leechcorepyc(void)
+PyMODINIT_FUNC PyInit_leechcorepyc(void)
 {
     return PyModule_Create(&LEECHCOREPYC_Module);
 }

--- a/leechcorepyc/leechcorepyc.c
+++ b/leechcorepyc/leechcorepyc.c
@@ -164,7 +164,7 @@ LEECHCOREPYC_Write(PyObject *self, PyObject *args)
     BOOL result;
     ULONG64 va;
     PBYTE pb, pbPy;
-    SIZE_T cb;
+    SIZE_T cb = 0;
     DWORD flags = 0;
     if(!PyArg_ParseTuple(args, "Ky#|k", &va, &pbPy, &cb, &flags)) { return NULL; }
     if(cb == 0) {

--- a/leechcorepyc/setup.py
+++ b/leechcorepyc/setup.py
@@ -1,0 +1,31 @@
+from distutils.core import setup, Extension
+
+leechcore_sources = [
+"../leechcore/device_file.c",
+"../leechcore/device_fpga.c",
+"../leechcore/device_hvsavedstate.c",
+"../leechcore/device_pmem.c",
+"../leechcore/device_rawtcp.c",
+"../leechcore/device_sp605tcp.c",
+"../leechcore/device_tmd.c",
+"../leechcore/device_usb3380.c",
+"../leechcore/fpga_libusb.c",
+"../leechcore/leechcore.c",
+"../leechcore/leechrpcclient.c",
+"../leechcore/memmap.c",
+"../leechcore/oscompatibility.c",
+"../leechcore/tlp.c",
+"../leechcore/util.c",
+]
+
+leechcorepyc = Extension('leechcorepyc',
+                    sources = ['leechcorepyc.c'] + leechcore_sources,
+                    libraries = ['usb-1.0'],
+                    define_macros = [("LINUX", "")],
+                    include_dirs = ["/usr/include/libusb-1.0/"],
+                    )
+
+setup (name = 'leechcorepyc',
+       version = '1.7',
+       description = 'LeechCore Python bindings',
+       ext_modules = [leechcorepyc])


### PR DESCRIPTION
This PR adds support for building the bindings on Linux through setup.py (`python setup.py build` and `python setup.py install`) and fixes 2 bugs I encountered:
* LEECHCOREPYC_Read returning empty results due to `cbRead` being always 0
* LEECHCOREPYC_Write trying to allocate large amount of memory (and failing) due to the upper bits of `cb` being unitialised.

I have only tested Read and Write on Linux, but the rest should work fine. 