### PR TITLE
Fix device parameter parsing on linux

### DIFF
--- a/leechcore/leechcore.c
+++ b/leechcore/leechcore.c
@@ -155,7 +155,7 @@ VOID LcCreate_FetchDeviceParameter(_Inout_ PLC_CONTEXT ctxLC)
         szParameters = NULL;
         if(!(szDelim = strstr(szToken, "="))) { continue; }
         pe = &ctxLC->pDeviceParameter[ctxLC->cDeviceParameter];
-        strncpy_s(pe->szName, _countof(pe->szName), szToken, szDelim - szToken);
+        compat_strncpy_s(pe->szName, _countof(pe->szName), szToken, szDelim - szToken);
         strncpy_s(pe->szValue, _countof(pe->szValue), szDelim + 1, _TRUNCATE);
         pe->qwValue = Util_GetNumericA(pe->szValue);
         if((0 == pe->qwValue) && !_stricmp(pe->szValue, "true")) {

--- a/leechcore/oscompatibility.c
+++ b/leechcore/oscompatibility.c
@@ -348,4 +348,14 @@ DWORD WaitForMultipleObjects(_In_ DWORD nCount, HANDLE *lpHandles, _In_ BOOL bWa
     return -1;
 }
 
+int compat_strncpy_s(char *strDest, size_t numberOfElements, const char *strSource, size_t count)
+{
+    // on windows, strncpy_s always nul-terminates the output. emulate that behavior
+    int ret = strncpy_s(strDest, numberOfElements, strSource, count);
+    if (numberOfElements > count) {
+        strDest[count] = '\0';
+    }
+    return ret;
+}
+
 #endif /* LINUX */

--- a/leechcore/oscompatibility.h
+++ b/leechcore/oscompatibility.h
@@ -22,6 +22,8 @@ typedef unsigned __int64                    QWORD, *PQWORD;
 #define LC_LIBRARY_FILETYPE                 ".dll"
 VOID usleep(_In_ DWORD us);
 
+#define compat_strncpy_s strncpy_s
+
 #endif /* _WIN32 */
 #ifdef LINUX
 #include <libusb.h>
@@ -219,6 +221,8 @@ BOOL SetEvent(_In_ HANDLE hEvent);
 HANDLE CreateEvent(_In_opt_ PVOID lpEventAttributes, _In_ BOOL bManualReset, _In_ BOOL bInitialState, _In_opt_ PVOID lpName);
 DWORD WaitForMultipleObjects(_In_ DWORD nCount, HANDLE *lpHandles, _In_ BOOL bWaitAll, _In_ DWORD dwMilliseconds);
 DWORD WaitForSingleObject(_In_ HANDLE hHandle, _In_ DWORD dwMilliseconds);
+
+int compat_strncpy_s(char *strDest, size_t numberOfElements, const char *strSource, size_t count);
 
 #endif /* LINUX */
 


### PR DESCRIPTION
There is a slight difference in strncpy_s behavior between windows and linux.

- On linux: "If count is reached before the entire array src was copied, the resulting character array is not null-terminated." https://en.cppreference.com/w/c/string/byte/strncpy
- On windows: "If those D characters will fit within strDest (whose size is given as numberOfElements) and still leave room for a null terminator, then those characters are copied and a terminating null is appended;" https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strncpy-s-strncpy-s-l-wcsncpy-s-wcsncpy-s-l-mbsncpy-s-mbsncpy-s-l?view=vs-2019

Basically, if count < strlen, windows adds a null terminator while linux does not.

This difference manifests when parsing device parameters. When szToken is `devindex=1`, and szDelim points to the `=`, pe->szName will be `devindex` on windows but `devindex=1` on linux. This leads to later `LcDeviceParameterGet` calls breaking.

This PR contains my proposed fix: A new compat_strncpy_s function that on windows is aliased to strncpy_s and on linux simply adds the null terminator after count. This PR fixes the bug I encountered but there are many other uses of strncpy_s that might need to be replaced, so this is a draft PR for now. I also cannot test on windows, but it doesn't look like this change should be an issue there.