### PR TITLE
oscompatibility: Fix strncpy_s macro

### DIFF
--- a/leechcore/oscompatibility.h
+++ b/leechcore/oscompatibility.h
@@ -122,7 +122,7 @@ typedef struct tdEXCEPTION_RECORD64         { CHAR sz[152]; } EXCEPTION_RECORD64
 #define _countof(_Array)                    (sizeof(_Array) / sizeof(_Array[0]))
 #define strnlen_s(s, maxcount)              (strnlen(s, maxcount))
 #define strcpy_s(dst, len, src)             (strncpy(dst, src, len))
-#define strncpy_s(dst, len, src, srclen)    (strncpy(dst, src, len))
+#define strncpy_s(dst, len, src, srclen)    (strncpy(dst, src, ((len) > (srclen)) ? (srclen) : (len)))
 #define strcat_s(dst, len, src)             (strcat(dst, src))
 #define strncat_s(dst, len, src, srclen)    (strncat(dst, src, srclen))
 #define _stricmp(s1, s2)                    (strcasecmp(s1, s2))


### PR DESCRIPTION
In [leechcore/leechcore.c:158](https://github.com/ufrisk/LeechCore/blob/master/leechcore/leechcore.c#L158-L159), where the device parameters are parsed, e.g. `udpraw://ip=192.168.0.222`, strncpy_s ends up always copying the full length of the string. This leads to the key `ip` becoming the full token `ip=192.168.0.222` which breaks the logic later on. Found this when trying to connect to an NeTV2 over UDP on a Linux host.

It turns out this was caused by the strncpy_s macro in leechcore/oscompatibility.h.