### PR TITLE
Python binding improvements - mark 2

### DIFF
--- a/leechcorepyc/leechcorepyc.c
+++ b/leechcorepyc/leechcorepyc.c
@@ -6,24 +6,27 @@
 #define Py_LIMITED_API 0x03060000
 #ifdef _DEBUG
 #undef _DEBUG
-#include <python.h>
+#include <Python.h>
 #define _DEBUG
 #else
-#include <python.h>
+#include <Python.h>
 #endif
+#ifdef _WIN32
 #include <Windows.h>
+#endif
 #include <leechcore.h>
+#include "../leechcore/oscompatibility.h"
 
 HANDLE g_hLC = NULL;
 
-inline int PyDict_SetItemString_DECREF(PyObject *dp, const char *key, PyObject *item)
+int PyDict_SetItemString_DECREF(PyObject *dp, const char *key, PyObject *item)
 {
     int i = PyDict_SetItemString(dp, key, item);
     Py_XDECREF(item);
     return i;
 }
 
-inline int PyList_Append_DECREF(PyObject *dp, PyObject *item)
+int PyList_Append_DECREF(PyObject *dp, PyObject *item)
 {
     int i = PyList_Append(dp, item);
     Py_XDECREF(item);

--- a/leechcorepyc/setup.py
+++ b/leechcorepyc/setup.py
@@ -1,0 +1,26 @@
+from distutils.core import setup, Extension
+
+leechcore_sources = [
+"../leechcore/device_file.c",
+"../leechcore/device_fpga.c",
+"../leechcore/device_pmem.c",
+"../leechcore/device_tmd.c",
+"../leechcore/device_usb3380.c",
+"../leechcore/leechcore.c",
+"../leechcore/leechrpcclient.c",
+"../leechcore/memmap.c",
+"../leechcore/oscompatibility.c",
+"../leechcore/util.c",
+]
+
+leechcorepyc = Extension('leechcorepyc',
+                    sources = ['leechcorepyc.c'] + leechcore_sources,
+                    libraries = ['usb-1.0'],
+                    define_macros = [("LINUX", "")],
+                    include_dirs = ["/usr/include/libusb-1.0/"],
+                    )
+
+setup (name = 'leechcorepyc',
+       version = '1.7',
+       description = 'LeechCore Python bindings',
+       ext_modules = [leechcorepyc])


### PR DESCRIPTION
Hiya, I just tried building the python bindings for linux and found pull request #14.  I've tried to update it to the support the latest version, but I have to admit my C code isn't all that great.

It compiles just fine, but `LcCreate` fails and I've no idea how to add the structure needed to `LcCreateEx` to see what's actually causing the problem.  On the same system I can run leechcore with the same device parameter and it reads just fine.

I'm happy to help test and develop improvements, but my C skills are pretty basic.  Anything that can help drive this forward a bit would be appreciated.  It feels like so much work has already been done, there's just a little bit extra needed to get linux supported too...  5:)