### PR TITLE
Fix building with musl libc

### DIFF
--- a/leechcore/oscompatibility.h
+++ b/leechcore/oscompatibility.h
@@ -150,13 +150,19 @@ typedef int(*_CoreCrtNonSecureSearchSortCompareFunction)(void const *, void cons
 #define ExitThread(dwExitCode)              (pthread_exit(dwExitCode))
 #define ExitProcess(c)                      (exit(c ? EXIT_SUCCESS : EXIT_FAILURE))
 #define Sleep(dwMilliseconds)               (usleep(1000*dwMilliseconds))
-#define fopen_s(ppFile, szFile, szAttr)     ((*ppFile = fopen64(szFile, szAttr)) ? 0 : 1)
 #define GetModuleFileNameA(m, f, l)         (readlink("/proc/self/exe", f, l))
 #define ZeroMemory(pb, cb)                  (memset(pb, 0, cb))
 #define WinUsb_SetPipePolicy(h, p, t, cb, pb)   // TODO: implement this for better USB2 performance.
 #define WSAGetLastError()                   (WSAEWOULDBLOCK)    // TODO: remove this dummy when possible.
+#ifdef __GLIBC__
+#define fopen_s(ppFile, szFile, szAttr)     ((*ppFile = fopen64(szFile, szAttr)) ? 0 : 1)
 #define _ftelli64(f)                        (ftello64(f))
 #define _fseeki64(f, o, w)                  (fseeko64(f, o, w))
+#else
+#define fopen_s(ppFile, szFile, szAttr)     ((*ppFile = fopen(szFile, szAttr)) ? 0 : 1)
+#define _ftelli64(f)                        (ftello(f))
+#define _fseeki64(f, o, w)                  (fseeko(f, o, w))
+#endif // __GLIBC__
 #define _chsize_s(fd, cb)                   (ftruncate64(fd, cb))
 #define _fileno(f)                          (fileno(f))
 #define InterlockedAdd64(p, v)              (__sync_add_and_fetch_8(p, v))


### PR DESCRIPTION
On musl lib fseeko64 is not supported, and building on musl gives the following error:

In file included from util.h:10,
                 from device_file.c:9:
device_file.c: In function 'DeviceFile_ReadContigious': oscompatibility.h:159:46: error: implicit declaration of function 'fseeko64'; did you mean 'fseeko'? [-Wimplicit-function-declaration]
  159 | #define _fseeki64(f, o, w)                  (fseeko64(f, o, w))
      |                                              ^~~~~~~~
device_file.c:197:13: note: in expansion of macro '_fseeki64'
  197 |     if(0 == _fseeki64(ctx->File[0].h, ctxRC->paBase, SEEK_SET)) {
      |             ^~~~~~~~~

For now I've wrapped the definitions around #ifdef's, so that fseeko64 and other similar fucntions are only used under GLIBC and on musl we can use the supported fseeko (and other supported) functions. But I'm open to better approach as this could lead to macro hell.

First reported on Gentoo Linux on musl profile. Please refer: https://bugs.gentoo.org/935917