### PR TITLE
fix can't get maped file

### DIFF
--- a/leechcore/device_vmware.c
+++ b/leechcore/device_vmware.c
@@ -60,7 +60,7 @@ BOOL DeviceVMWare_Open_GetRange(_In_ DWORD dwPID, _Out_writes_opt_(42) LPWSTR ws
 {
     DWORD cch;
     HANDLE hProcess = 0;
-    QWORD va = 0x0000001000000000;
+    QWORD va = 0x0000000000000000;
     WCHAR wsz[MAX_PATH + 1] = { 0 };
     MEMORY_BASIC_INFORMATION BI;
     hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwPID);


### PR DESCRIPTION
Some addresses are less than 0x1000000000, which can cause scanning failure. Starting from 0 can solve this problem