### PR TITLE
fix can't get maped file

### DIFF
--- a/leechcore/device_vmware.c
+++ b/leechcore/device_vmware.c
@@ -60,7 +60,7 @@ BOOL DeviceVMWare_Open_GetRange(_In_ DWORD dwPID, _Out_writes_opt_(42) LPWSTR ws
 {
     DWORD cch;
     HANDLE hProcess = 0;
-    QWORD va = 0x0000001000000000;
+    QWORD va = 0x0000000000000000;
     WCHAR wsz[MAX_PATH + 1] = { 0 };
     MEMORY_BASIC_INFORMATION BI;
     hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwPID);


### PR DESCRIPTION
Some addresses are less than 0x1000000000, which can cause scanning failure. Starting from 0 can solve this problem.

BSD Zero Clause License

Copyright (c) 2025 moshui

Permission to use, copy, modify, and/or distribute this software for any
purpose with or without fee is hereby granted.

THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
PERFORMANCE OF THIS SOFTWARE.