### PR TITLE
Make sure error messages are always shown

### DIFF
--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -4057,7 +4057,7 @@ fail:
             DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);
         }
         dwVIDPID = *(PDWORD)pb200;
-        lcprintfv(ctxLC,
+        lcprintf(ctxLC,
             "DEVICE: FPGA: ERROR: %s [%i,v%i.%i,%04x%s]\n",
             szDeviceError,
             ctx->wFpgaID,

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -4051,7 +4051,7 @@ fail:
     if(ctxLC->fPrintf[LC_PRINTF_VV] && ctx->dev.fInitialized) {
         DeviceFPGA_ConfigPrint(ctxLC, ctx);
     }
-    if(szDeviceError && ctxLC->fPrintf[LC_PRINTF_V]) {
+    if(szDeviceError) {
         *(PDWORD)pb200 = 0;
         if(ctx->dev.fInitialized && ctx->wFpgaVersionMajor) {
             DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);

--- a/leechcore/leechcore.c
+++ b/leechcore/leechcore.c
@@ -454,10 +454,10 @@ EXPORTED_FUNCTION HANDLE LcCreateEx(_Inout_ PLC_CONFIG pLcCreateConfig, _Out_opt
     ctxLC->dwHandleCount = 1;
     ctxLC->cMemMapMax = 0x20;
     ctxLC->pMemMap = LocalAlloc(LMEM_ZEROINIT, ctxLC->cMemMapMax * sizeof(LC_MEMMAP_ENTRY));
-    ctxLC->fPrintf[0] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_ENABLED) ? TRUE : FALSE;
-    ctxLC->fPrintf[1] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_V) ? TRUE : FALSE;
-    ctxLC->fPrintf[2] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_VV) ? TRUE : FALSE;
-    ctxLC->fPrintf[3] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_VVV) ? TRUE : FALSE;
+    ctxLC->fPrintf[LC_PRINTF_ENABLE] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_ENABLED) ? TRUE : FALSE;
+    ctxLC->fPrintf[LC_PRINTF_V] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_V) ? TRUE : FALSE;
+    ctxLC->fPrintf[LC_PRINTF_VV] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_VV) ? TRUE : FALSE;
+    ctxLC->fPrintf[LC_PRINTF_VVV] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_VVV) ? TRUE : FALSE;
     LcCreate_FetchDeviceParameter(ctxLC);
     LcCreate_FetchDevice(ctxLC);
     if(!ctxLC->pfnCreate || !ctxLC->pfnCreate(ctxLC, ppLcCreateErrorInfo) || !LcReadContigious_Initialize(ctxLC)) {

--- a/leechcore/leechcore_device.h
+++ b/leechcore/leechcore_device.h
@@ -139,14 +139,14 @@ EXPORTED_FUNCTION PLC_DEVICE_PARAMETER_ENTRY LcDeviceParameterGet(_In_ PLC_CONTE
 */
 EXPORTED_FUNCTION QWORD LcDeviceParameterGetNumeric(_In_ PLC_CONTEXT ctxLC, _In_ LPSTR szName);
 
-#define lcprintf(ctxLC, _Format, ...)        { if(ctxLC->fPrintf[0]) { ctxLC->Config.pfn_printf_opt ? ctxLC->Config.pfn_printf_opt(_Format, ##__VA_ARGS__) : printf(_Format, ##__VA_ARGS__); } }
-#define lcprintfv(ctxLC, _Format, ...)       { if(ctxLC->fPrintf[1]) { lcprintf(ctxLC, _Format, ##__VA_ARGS__); } }
-#define lcprintfvv(ctxLC, _Format, ...)      { if(ctxLC->fPrintf[2]) { lcprintf(ctxLC, _Format, ##__VA_ARGS__); } }
-#define lcprintfvvv(ctxLC, _Format, ...)     { if(ctxLC->fPrintf[3]) { lcprintf(ctxLC, _Format, ##__VA_ARGS__); } }
-#define lcprintf_fn(ctxLC, _Format, ...)     { if(ctxLC->fPrintf[0]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
-#define lcprintfv_fn(ctxLC, _Format, ...)    { if(ctxLC->fPrintf[1]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
-#define lcprintfvv_fn(ctxLC, _Format, ...)   { if(ctxLC->fPrintf[2]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
-#define lcprintfvvv_fn(ctxLC, _Format, ...)  { if(ctxLC->fPrintf[3]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
+#define lcprintf(ctxLC, _Format, ...)        { if(ctxLC->fPrintf[LC_PRINTF_ENABLE]) { ctxLC->Config.pfn_printf_opt ? ctxLC->Config.pfn_printf_opt(_Format, ##__VA_ARGS__) : printf(_Format, ##__VA_ARGS__); } }
+#define lcprintfv(ctxLC, _Format, ...)       { if(ctxLC->fPrintf[LC_PRINTF_V]) { lcprintf(ctxLC, _Format, ##__VA_ARGS__); } }
+#define lcprintfvv(ctxLC, _Format, ...)      { if(ctxLC->fPrintf[LC_PRINTF_VV]) { lcprintf(ctxLC, _Format, ##__VA_ARGS__); } }
+#define lcprintfvvv(ctxLC, _Format, ...)     { if(ctxLC->fPrintf[LC_PRINTF_VVV]) { lcprintf(ctxLC, _Format, ##__VA_ARGS__); } }
+#define lcprintf_fn(ctxLC, _Format, ...)     { if(ctxLC->fPrintf[LC_PRINTF_ENABLE]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
+#define lcprintfv_fn(ctxLC, _Format, ...)    { if(ctxLC->fPrintf[LC_PRINTF_V]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
+#define lcprintfvv_fn(ctxLC, _Format, ...)   { if(ctxLC->fPrintf[LC_PRINTF_VV]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
+#define lcprintfvvv_fn(ctxLC, _Format, ...)  { if(ctxLC->fPrintf[LC_PRINTF_VVV]) { lcprintf(ctxLC, "%s: "_Format, __func__, ##__VA_ARGS__); } }
 
 /*
 * Check whether the memory map is initialized or not.


### PR DESCRIPTION
Make sure error messages are always shown
This makes it more clear where the error comes from without resorting to more verbose messages.

I also make more use of provided constants.

BSD Zero Clause License

Copyright (c) 2026 Remco Poelstra

Permission to use, copy, modify, and/or distribute this software for any
purpose with or without fee is hereby granted.

THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
PERFORMANCE OF THIS SOFTWARE.