### PR TITLE
Make sure pyc clients also imply printf and verbose on extra verbose

### DIFF
--- a/leechcore/leechcore.c
+++ b/leechcore/leechcore.c
@@ -454,8 +454,8 @@ EXPORTED_FUNCTION HANDLE LcCreateEx(_Inout_ PLC_CONFIG pLcCreateConfig, _Out_opt
     ctxLC->dwHandleCount = 1;
     ctxLC->cMemMapMax = 0x20;
     ctxLC->pMemMap = LocalAlloc(LMEM_ZEROINIT, ctxLC->cMemMapMax * sizeof(LC_MEMMAP_ENTRY));
-    ctxLC->fPrintf[LC_PRINTF_ENABLE] = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_ENABLED) ? TRUE : FALSE;
-    ctxLC->fPrintf[LC_PRINTF_V]      = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_V) ? TRUE : FALSE;
+    ctxLC->fPrintf[LC_PRINTF_ENABLE] = (ctxLC->Config.dwPrintfVerbosity & (LC_CONFIG_PRINTF_ENABLED | LC_CONFIG_PRINTF_V | LC_CONFIG_PRINTF_VV | LC_CONFIG_PRINTF_VVV)) ? TRUE : FALSE;
+    ctxLC->fPrintf[LC_PRINTF_V]      = (ctxLC->Config.dwPrintfVerbosity & (LC_CONFIG_PRINTF_V | LC_CONFIG_PRINTF_VV)) ? TRUE : FALSE;
     ctxLC->fPrintf[LC_PRINTF_VV]     = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_VV) ? TRUE : FALSE;
     ctxLC->fPrintf[LC_PRINTF_VVV]    = (ctxLC->Config.dwPrintfVerbosity & LC_CONFIG_PRINTF_VVV) ? TRUE : FALSE;
     LcCreate_FetchDeviceParameter(ctxLC);


### PR DESCRIPTION
Hi,

I noticed that pyc clients did not automatically imply verbose on extra verbose (nor enable printf). So I've added that as well.

BSD Zero Clause License

Copyright (c) 2026 Remco Poelstra

Permission to use, copy, modify, and/or distribute this software for any
purpose with or without fee is hereby granted.

THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
PERFORMANCE OF THIS SOFTWARE.