### PR TITLE
fix(fpga): honor FIRST markers when framing TLPs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.sh text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/leechcore/Makefile
+++ b/leechcore/Makefile
@@ -10,7 +10,7 @@ CFLAGS  += -fPIE -fPIC -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O1 -Wl
 CFLAGS  += -Wall -Wno-multichar -Wno-unused-result -Wno-unused-variable -Wno-unused-value -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 LDFLAGS += -g -ldl -shared
 DEPS = leechcore.h
-OBJ = oscompatibility.o leechcore.o charutil.o util.o memmap.o device_file.o device_fpga.o device_hibr.o device_pmem.o device_tmd.o device_usb3380.o device_vmm.o device_vmware.o leechrpcclient.o ob/ob_core.o ob/ob_map.o ob/ob_set.o ob/ob_bytequeue.o
+OBJ = oscompatibility.o leechcore.o charutil.o util.o memmap.o device_file.o device_fpga.o device_fpga_session.o device_hibr.o device_pmem.o device_tmd.o device_usb3380.o device_vmm.o device_vmware.o leechrpcclient.o ob/ob_core.o ob/ob_map.o ob/ob_set.o ob/ob_bytequeue.o
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS)

--- a/leechcore/Makefile.macos
+++ b/leechcore/Makefile.macos
@@ -11,7 +11,7 @@ CFLAGS += -mmacosx-version-min=11.0
 LDFLAGS += -g -dynamiclib -mmacosx-version-min=11.0
 
 DEPS = leechcore.h
-OBJ = oscompatibility.o leechcore.o charutil.o util.o memmap.o device_file.o device_fpga.o device_hibr.o device_pmem.o device_tmd.o device_usb3380.o device_vmm.o device_vmware.o leechrpcclient.o ob/ob_core.o ob/ob_map.o ob/ob_set.o ob/ob_bytequeue.o
+OBJ = oscompatibility.o leechcore.o charutil.o util.o memmap.o device_file.o device_fpga.o device_fpga_session.o device_hibr.o device_pmem.o device_tmd.o device_usb3380.o device_vmm.o device_vmware.o leechrpcclient.o ob/ob_core.o ob/ob_map.o ob/ob_set.o ob/ob_bytequeue.o
 
 # ARCH SPECIFIC FLAGS:
 CFLAGS_X86_64  = $(CFLAGS) -arch x86_64

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -14,16 +14,13 @@
 #include "leechcore_device.h"
 #include "leechcore_internal.h"
 #include "oscompatibility.h"
+#include "device_fpga_session.h"
 #include "util.h"
 #include "ob/ob.h"
 
 //-------------------------------------------------------------------------------
 // FPGA defines below.
 //-------------------------------------------------------------------------------
-
-#define FPGA_CMD_VERSION_MAJOR          0x01
-#define FPGA_CMD_DEVICE_ID              0x03
-#define FPGA_CMD_VERSION_MINOR          0x05
 
 #define FPGA_REG_CORE                 0x0003
 #define FPGA_REG_PCIE                 0x0001
@@ -1213,10 +1210,9 @@ VOID DeviceFPGA_Close(_Inout_ PLC_CONTEXT ctxLC)
 _Success_(return)
 BOOL DeviceFPGA_ConfigRead(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, _Out_writes_(cb) PBYTE pb, _In_ WORD cb, _In_ WORD flags)
 {
-    BOOL f, fReturn = FALSE;
+    BOOL fReturn = FALSE;
     PBYTE pbRxTx = NULL;
-    DWORD i, j, status, dwStatus, dwData, cbRxTx = 0;
-    PDWORD pdwData;
+    DWORD status, cbRxTx = 0;
     WORD wAddr;
     if(!cb || (wBaseAddr + cb > 0x1000)) { goto fail; }
     if(!(pbRxTx = LocalAlloc(LMEM_ZEROINIT, 0x20000))) { goto fail; }
@@ -1241,35 +1237,7 @@ BOOL DeviceFPGA_ConfigRead(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, _
     // READ and interpret result
     status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, pbRxTx, 0x20000, &cbRxTx, NULL);
     if(status) { goto fail; }
-    ZeroMemory(pb, cb);
-    for(i = 0; i < cbRxTx; i += 32) {
-        while(*(PDWORD)(pbRxTx + i) == 0x55556666) { // skip over ftdi workaround dummy fillers
-            i += 4;
-            if(i + 32 > cbRxTx) { goto fail; }
-        }
-        dwStatus = *(PDWORD)(pbRxTx + i);
-        pdwData = (PDWORD)(pbRxTx + i + 4);
-        if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
-        for(j = 0; j < 7; j++) {
-            f = (dwStatus & 0x0f) == (flags & 0x03);
-            dwData = *pdwData;
-            pdwData++;                              // move ptr to next data
-            dwStatus >>= 4;                         // move to next status
-            if(!f) { continue; }                    // status src flags does not match source
-            wAddr = _byteswap_ushort((WORD)dwData);
-            wAddr -= (flags & 0xC000) + wBaseAddr;  // adjust for base address and read-write config memory
-            if(wAddr == 0xffff) {   // 1st unaligned byte
-                *pb = (dwData >> 24) & 0xff;
-            }
-            if(wAddr >= cb) { continue; }           // address read is out of range
-            if(wAddr == cb - 1) {   // last byte
-                *(PBYTE)(pb + wAddr) = (dwData >> 16) & 0xff;
-            } else {                // normal two-bytes
-                *(PWORD)(pb + wAddr) = (dwData >> 16) & 0xffff;
-            }
-        }
-    }
-    fReturn = TRUE;
+    fReturn = DeviceFPGA_Session_ParseConfigReply(pbRxTx, cbRxTx, wBaseAddr, pb, cb, flags);
 fail:
     LocalFree(pbRxTx);
     return fReturn;
@@ -1787,14 +1755,34 @@ VOID DeviceFPGA_HotResetV4(_In_ PDEVICE_CONTEXT_FPGA ctx)
 }
 
 _Success_(return)
+static BOOL DeviceFPGA_GetDeviceID_FpgaVersionV4_ConfigRead(
+    _In_ PVOID pvContext,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cb) PBYTE pb,
+    _In_ WORD cb,
+    _In_ WORD flags
+)
+{
+    return DeviceFPGA_ConfigRead((PDEVICE_CONTEXT_FPGA)pvContext, wBaseAddr, pb, cb, flags);
+}
+
+_Success_(return)
 BOOL DeviceFPGA_GetDeviceID_FpgaVersionV4(_In_ PDEVICE_CONTEXT_FPGA ctx)
 {
+    DEVICE_FPGA_IDENTITY Identity;
     WORD wbsDeviceId = 0, wMagicPCIe = 0;
     DWORD dwInactivityTimer = 0x000186a0;       // set inactivity timer to 1ms ( 0x0186a0 * 100MHz ) [only later activated on UDP bitstreams]
     DWORD cNfWarm = 0;
-    if(!DeviceFPGA_ConfigRead(ctx, 0x0008, (PBYTE)&ctx->wFpgaVersionMajor, 1, FPGA_REG_CORE | FPGA_REG_READONLY) || ctx->wFpgaVersionMajor < 4) { return FALSE; }
-    DeviceFPGA_ConfigRead(ctx, 0x0009, (PBYTE)&ctx->wFpgaVersionMinor, 1, FPGA_REG_CORE | FPGA_REG_READONLY);
-    DeviceFPGA_ConfigRead(ctx, 0x000a, (PBYTE)&ctx->wFpgaID, 1, FPGA_REG_CORE | FPGA_REG_READONLY);
+    if(!DeviceFPGA_Session_ReadV4Identity(
+        ctx,
+        DeviceFPGA_GetDeviceID_FpgaVersionV4_ConfigRead,
+        FPGA_REG_CORE | FPGA_REG_READONLY,
+        &Identity)) {
+        return FALSE;
+    }
+    ctx->wFpgaVersionMajor = Identity.wVersionMajor;
+    ctx->wFpgaVersionMinor = Identity.wVersionMinor;
+    ctx->wFpgaID = Identity.wFpgaID;
     DeviceFPGA_ConfigWrite(ctx, 0x0008, (PBYTE)&dwInactivityTimer, 4, FPGA_REG_CORE | FPGA_REG_READWRITE);
     // PCIe
     while(!wbsDeviceId && (cNfWarm++ < 4)) {
@@ -1810,71 +1798,47 @@ BOOL DeviceFPGA_GetDeviceID_FpgaVersionV4(_In_ PDEVICE_CONTEXT_FPGA ctx)
     return TRUE;
 }
 
-VOID DeviceFPGA_GetDeviceID_FpgaVersionV3(_In_ PDEVICE_CONTEXT_FPGA ctx)
+_Success_(return)
+BOOL DeviceFPGA_GetDeviceID_FpgaVersionV3(_In_ PDEVICE_CONTEXT_FPGA ctx)
 {
     DWORD status;
-    DWORD cbTX, cbRX, i, j;
+    DWORD cbTX, cbRX;
     BYTE pbRX[0x1000];
-    DWORD dwStatus, dwData, cdwCfg = 0;
-PDWORD pdwData;
-BYTE pbTX[] = {
-    // cfg status: (pcie bus,dev,fn id)
-    0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x01, 0x77,
-    // cmd msg: FPGA bitstream version (major)
-    0x00, 0x00, 0x00, 0x00,  0x01, 0x00, 0x03, 0x77,
-    // cmd msg: FPGA bitstream version (minor)
-    0x00, 0x00, 0x00, 0x00,  0x05, 0x00, 0x03, 0x77,
-    // cmd msg: FPGA bitstream device id
-    0x00, 0x00, 0x00, 0x00,  0x03, 0x00, 0x03, 0x77
-};
-// Write and read data from device.
-status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbTX, sizeof(pbTX), &cbTX, NULL);
-if(status) { return; }
-Sleep(10);
-status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, pbRX, sizeof(pbRX), &cbRX, NULL);
-if(status) { return; }
-// Interpret read data
-for(i = 0; i < cbRX; i += 32) {
-    while(*(PDWORD)(pbRX + i) == 0x55556666) { // skip over ftdi workaround dummy fillers
-        i += 4;
-        if(i + 32 > cbRX) { return; }
+    WORD wPcieDeviceId;
+    DEVICE_FPGA_IDENTITY Identity;
+    BYTE pbTX[] = {
+        // cfg status: (pcie bus,dev,fn id)
+        0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x01, 0x77,
+        // cmd msg: FPGA bitstream version (major)
+        0x00, 0x00, 0x00, 0x00,  0x01, 0x00, 0x03, 0x77,
+        // cmd msg: FPGA bitstream version (minor)
+        0x00, 0x00, 0x00, 0x00,  0x05, 0x00, 0x03, 0x77,
+        // cmd msg: FPGA bitstream device id
+        0x00, 0x00, 0x00, 0x00,  0x03, 0x00, 0x03, 0x77
+    };
+    // Write and read data from device.
+    status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbTX, sizeof(pbTX), &cbTX, NULL);
+    if(status) { return FALSE; }
+    Sleep(10);
+    status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, pbRX, sizeof(pbRX), &cbRX, NULL);
+    if(status) { return FALSE; }
+    if(!DeviceFPGA_Session_ParseV3Identity(pbRX, cbRX, &Identity, &wPcieDeviceId)) {
+        return FALSE;
     }
-    dwStatus = *(PDWORD)(pbRX + i);
-    pdwData = (PDWORD)(pbRX + i + 4);
-    if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
-    for(j = 0; j < 7; j++) {
-        dwData = *pdwData;
-        if((dwStatus & 0x03) == 0x03) { // CMD REPLY (or filler)
-            switch(dwData >> 24) {
-                case FPGA_CMD_VERSION_MAJOR:
-                    ctx->wFpgaVersionMajor = (WORD)dwData;
-                    break;
-                case FPGA_CMD_VERSION_MINOR:
-                    ctx->wFpgaVersionMinor = (WORD)dwData;
-                    break;
-                case FPGA_CMD_DEVICE_ID:
-                    ctx->wFpgaID = (WORD)dwData;
-                    break;
-            }
-        }
-        if((dwStatus & 0x03) == 0x01) { // PCIe CFG REPLY
-            if(((++cdwCfg % 2) == 0) && (WORD)dwData) {    // DeviceID: (pcie bus,dev,fn id)
-                ctx->wDeviceId = (WORD)dwData;
-            }
-        }
-        pdwData++;
-        dwStatus >>= 4;
-    }
-}
-ctx->phySupported = (ctx->wFpgaVersionMajor >= 3) ? DeviceFPGA_GetSetPHYv3(ctx, FALSE) : FALSE;
+    ctx->wFpgaVersionMajor = Identity.wVersionMajor;
+    ctx->wFpgaVersionMinor = Identity.wVersionMinor;
+    ctx->wFpgaID = Identity.wFpgaID;
+    ctx->wDeviceId = wPcieDeviceId;
+    ctx->phySupported = (ctx->wFpgaVersionMajor >= 3) ? DeviceFPGA_GetSetPHYv3(ctx, FALSE) : FALSE;
+    return TRUE;
 }
 
-VOID DeviceFPGA_GetDeviceID_FpgaVersion(_In_ PDEVICE_CONTEXT_FPGA ctx)
+_Success_(return)
+BOOL DeviceFPGA_GetDeviceID_FpgaVersion(_In_ PDEVICE_CONTEXT_FPGA ctx)
 {
     DeviceFPGA_GetDeviceId_FpgaVersion_ClearPipe(ctx);
-    if(!DeviceFPGA_GetDeviceID_FpgaVersionV4(ctx)) {
-        DeviceFPGA_GetDeviceID_FpgaVersionV3(ctx);
-    }
+    if(DeviceFPGA_GetDeviceID_FpgaVersionV4(ctx)) { return TRUE; }
+    return DeviceFPGA_GetDeviceID_FpgaVersionV3(ctx);
 }
 
 VOID DeviceFPGA_SetPerformanceProfile(_Inout_ PDEVICE_CONTEXT_FPGA ctx)
@@ -3971,8 +3935,7 @@ BOOL DeviceFPGA_Open(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO 
     ctx->fRestartDevice = (1 == LcDeviceParameterGetNumeric(ctxLC, FPGA_PARAMETER_RESTART_DEVICE));
     ctx->bAT = (BYTE)LcDeviceParameterGetNumeric(ctxLC, FPGA_PARAMETER_ATS);
     ctx->fATS = ((ctx->bAT >= 1) && (ctx->bAT <= 3));
-    DeviceFPGA_GetDeviceID_FpgaVersion(ctx);
-    if(!ctx->wFpgaVersionMajor) {
+    if(!DeviceFPGA_GetDeviceID_FpgaVersion(ctx) || !ctx->wFpgaVersionMajor) {
         szDeviceError = "Unable to connect to FPGA device";
         goto fail;
     }

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -2273,10 +2273,15 @@ VOID DeviceFPGA_Synch_RxTlpSynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONT
 {
     DWORD status;
     BOOL fRetry = FALSE;
-    DWORD i = 0, j, cdwTlp = 0, cbReadRxBuf;
+    DWORD i = 0, j, cbReadRxBuf;
     BYTE pbTlp[TLP_RX_MAX_SIZE];
     PDWORD pdwTlp = (PDWORD)pbTlp;
     DWORD dwStatus, *pdwData, cbRx;
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE TlpFrame = { 0 };
+    DEVICE_FPGA_SESSION_TLP_FRAME_ACTION FrameAction;
+    TlpFrame.fRequireFirst =
+        (ctx->wFpgaVersionMajor > 4) ||
+        ((ctx->wFpgaVersionMajor == 4) && (ctx->wFpgaVersionMinor >= 13));
     // larger read buffer slows down FT_ReadPipe so set it fairly tight if possible.
     ctx->rxbuf.cb = 0;
     cbReadRxBuf = ctx->dev.f2232h ? ctx->rxbuf.cbMax :
@@ -2311,26 +2316,30 @@ VOID DeviceFPGA_Synch_RxTlpSynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONT
                 continue;
             }
             for(j = 0; j < 7; j++) {
-                if((dwStatus & 0x03) == 0x00) { // PCIe TLP
-                    pdwTlp[cdwTlp] = *pdwData;
-                    cdwTlp++;
-                    if(cdwTlp >= TLP_RX_MAX_SIZE / sizeof(DWORD)) { return; }
+                FrameAction = DeviceFPGA_Session_TlpFrameStep(
+                    &TlpFrame,
+                    (BYTE)dwStatus,
+                    TLP_RX_MAX_SIZE_IN_DWORDS);
+                if((FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_APPEND) ||
+                   (FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE) ||
+                   (FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_RESTART)) {
+                    pdwTlp[TlpFrame.cdwTlp - 1] = *pdwData;
                 }
-                if((dwStatus & 0x07) == 0x04) { // PCIe TLP and LAST
-                    if((cdwTlp >= 3) && (cdwTlp <= TLP_RX_MAX_SIZE_IN_DWORDS)) {
-                        if(ctxLC->fPrintf[LC_PRINTF_VVV]) {
-                            TLP_Print(ctxLC, pbTlp, cdwTlp << 2, FALSE);
-                        }
-                        if(ctx->tlp_callback.pBqRx) {
-                            DeviceFPGA_RxTlp_QueueUserCallback(ctx, (SIZE_T)cdwTlp << 2, pbTlp);
-                        }
-                        if(ctx->hRxTlpCallbackFn) {
-                            ctx->hRxTlpCallbackFn(ctx->pMRdBufferX, pbTlp, cdwTlp << 2);
-                        }
-                    } else {
-                        lcprintf(ctxLC, "Device Info: FPGA: Bad PCIe TLP received! Should not happen!\n");
+                if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_RESTART) {
+                    lcprintfvv(ctxLC, "Device Info: FPGA: TLP framing resynchronized at FIRST marker.\n");
+                } else if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED) {
+                    lcprintf(ctxLC, "Device Info: FPGA: Bad PCIe TLP received! Should not happen!\n");
+                } else if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE) {
+                    if(ctxLC->fPrintf[LC_PRINTF_VVV]) {
+                        TLP_Print(ctxLC, pbTlp, TlpFrame.cdwTlp << 2, FALSE);
                     }
-                    cdwTlp = 0;
+                    if(ctx->tlp_callback.pBqRx) {
+                        DeviceFPGA_RxTlp_QueueUserCallback(ctx, (SIZE_T)TlpFrame.cdwTlp << 2, pbTlp);
+                    }
+                    if(ctx->hRxTlpCallbackFn) {
+                        ctx->hRxTlpCallbackFn(ctx->pMRdBufferX, pbTlp, TlpFrame.cdwTlp << 2);
+                    }
+                    TlpFrame.cdwTlp = 0;
                 }
                 pdwData++;
                 dwStatus >>= 4;
@@ -2338,7 +2347,7 @@ VOID DeviceFPGA_Synch_RxTlpSynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONT
             i += 8 * 4;
         }
         // return upon (successful) finish!
-        if((cdwTlp == 0) || fRetry || (ctx->rxbuf.cbMax - ctx->rxbuf.cb < 0x400)) {
+        if((TlpFrame.cdwTlp == 0) || fRetry || (ctx->rxbuf.cbMax - ctx->rxbuf.cb < 0x400)) {
             return;
         }
         // read retry should be attempted (in case of partial tlp received at the end)
@@ -2596,7 +2605,12 @@ DWORD DeviceFPGA_Async2_Read_RxTlpSingle(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CO
 {
     BYTE pbTlp[TLP_RX_MAX_SIZE];
     PDWORD pdwTlp = (PDWORD)pbTlp;
-    DWORD i = 0, j, dwStatus, cdwTlp = 0, iStartWord;
+    DWORD i = 0, j, dwStatus, iStartWord;
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE TlpFrame = { 0 };
+    DEVICE_FPGA_SESSION_TLP_FRAME_ACTION FrameAction;
+    TlpFrame.fRequireFirst =
+        (ctx->wFpgaVersionMajor > 4) ||
+        ((ctx->wFpgaVersionMajor == 4) && (ctx->wFpgaVersionMinor >= 13));
     // skip over initial ftdi workaround dummy fillers / non valid octa-dwords
     while((i < cdwData) && ((pdwData[i] & 0xf0000000) != 0xe0000000)) {
         i++;
@@ -2615,27 +2629,45 @@ DWORD DeviceFPGA_Async2_Read_RxTlpSingle(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CO
             continue;
         }
         for(j = 0; j < 7; j++, i++) {
-            if((dwStatus & 0x03) == 0x00) { // PCIe TLP
-                if(cdwTlp >= TLP_RX_MAX_SIZE / sizeof(DWORD)) {
-                    // TODO: malformed TLP
-                    pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
-                    return iStartWord | 0x80000000;
-                }
-                pdwTlp[cdwTlp++] = pdwData[i];
+#ifdef LINUX
+            /*
+             * Completion payload DWORDs normally remain inside a frame with no
+             * status flags. Keep FIRST/LAST/error handling in the shared state
+             * machine, but avoid its branches for this dominant Linux hot path.
+             */
+            if(TlpFrame.fInTlp &&
+               !(dwStatus & 0x0f) &&
+               (TlpFrame.cdwTlp < TLP_RX_MAX_SIZE_IN_DWORDS)) {
+                pdwTlp[TlpFrame.cdwTlp++] = pdwData[i];
+                dwStatus >>= 4;
+                continue;
             }
-            if((dwStatus & 0x07) == 0x04) { // PCIe TLP and LAST
-                if((cdwTlp < 3) || (cdwTlp > TLP_RX_MAX_SIZE_IN_DWORDS)) {
-                    printf("Device Info: FPGA: Bad PCIe TLP received! Should not happen!\n");
-                    pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
-                    return iStartWord | 0x80000000;
+#endif /* LINUX */
+            FrameAction = DeviceFPGA_Session_TlpFrameStep(
+                &TlpFrame,
+                (BYTE)dwStatus,
+                TLP_RX_MAX_SIZE_IN_DWORDS);
+            if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE) {
+                if((dwStatus & 0x0b) == 0x00) {
+                    pdwData[iStartWord] |= 1U << (j << 2);
                 }
+            } else if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED) {
+                printf("Device Info: FPGA: Bad PCIe TLP received! Should not happen!\n");
+                pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
+                return iStartWord | 0x80000000;
+            } else {
+                pdwTlp[TlpFrame.cdwTlp - 1] = pdwData[i];
+            }
+            if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_RESTART) {
+                lcprintfvv(ctxLC, "Device Info: FPGA: TLP framing resynchronized at FIRST marker.\n");
+            } else if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE) {
                 if(ctxLC->fPrintf[LC_PRINTF_VVV]) {
-                    TLP_Print(ctxLC, pbTlp, cdwTlp << 2, FALSE);
+                    TLP_Print(ctxLC, pbTlp, TlpFrame.cdwTlp << 2, FALSE);
                 }
                 if(ctx->tlp_callback.pBqRx) {
-                    DeviceFPGA_RxTlp_QueueUserCallback(ctx, (SIZE_T)cdwTlp << 2, pbTlp);
+                    DeviceFPGA_RxTlp_QueueUserCallback(ctx, (SIZE_T)TlpFrame.cdwTlp << 2, pbTlp);
                 }
-                DeviceFPGA_Async2_Read_RxTlpSingle_MRdCpl(ctxLC, ctx, pbTlp, cdwTlp << 2);
+                DeviceFPGA_Async2_Read_RxTlpSingle_MRdCpl(ctxLC, ctx, pbTlp, TlpFrame.cdwTlp << 2);
                 pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
                 return iStartWord | 0x80000000;
             }
@@ -3075,7 +3107,12 @@ DWORD DeviceFPGA_SynchOldAsync_Tlp(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONTEXT_
 {
     BYTE pbTlp[TLP_RX_MAX_SIZE];
     PDWORD pdwTlp = (PDWORD)pbTlp;
-    DWORD i = 0, j, dwStatus, cdwTlp = 0, iStartWord;
+    DWORD i = 0, j, dwStatus, iStartWord;
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE TlpFrame = { 0 };
+    DEVICE_FPGA_SESSION_TLP_FRAME_ACTION FrameAction;
+    TlpFrame.fRequireFirst =
+        (ctx->wFpgaVersionMajor > 4) ||
+        ((ctx->wFpgaVersionMajor == 4) && (ctx->wFpgaVersionMinor >= 13));
     // skip over initial ftdi workaround dummy fillers / non valid octa-dwords
     while((i < cdwData) && ((pdwData[i] == 0x55556666) || ((pdwData[i] & 0xf0000000) != 0xe0000000))) {
         i++;
@@ -3089,28 +3126,32 @@ DWORD DeviceFPGA_SynchOldAsync_Tlp(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONTEXT_
             continue;
         }
         for(j = 0; j < 7; j++, i++) {
-            if((dwStatus & 0x03) == 0x00) { // PCIe TLP
-                if(cdwTlp >= TLP_RX_MAX_SIZE / sizeof(DWORD)) {
-                    // TODO: malformed TLP
-                    pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
-                    return iStartWord;
+            FrameAction = DeviceFPGA_Session_TlpFrameStep(
+                &TlpFrame,
+                (BYTE)dwStatus,
+                TLP_RX_MAX_SIZE_IN_DWORDS);
+            if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE) {
+                if((dwStatus & 0x0b) == 0x00) {
+                    pdwData[iStartWord] |= 1U << (j << 2);
                 }
-                pdwTlp[cdwTlp++] = pdwData[i];
+            } else if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED) {
+                printf("Device Info: FPGA: Bad PCIe TLP received! Should not happen!\n");
+                pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
+                return iStartWord;
+            } else {
+                pdwTlp[TlpFrame.cdwTlp - 1] = pdwData[i];
             }
-            if((dwStatus & 0x07) == 0x04) { // PCIe TLP and LAST
-                if(cdwTlp < 3) {
-                    printf("Device Info: FPGA: Bad PCIe TLP received! Should not happen!\n");
-                    pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
-                    return iStartWord;
-                }
+            if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_RESTART) {
+                lcprintfvv(ctxLC, "Device Info: FPGA: TLP framing resynchronized at FIRST marker.\n");
+            } else if(FrameAction == DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE) {
                 if(ctxLC->fPrintf[LC_PRINTF_VVV]) {
-                    TLP_Print(ctxLC, pbTlp, cdwTlp << 2, FALSE);
+                    TLP_Print(ctxLC, pbTlp, TlpFrame.cdwTlp << 2, FALSE);
                 }
                 if(ctx->tlp_callback.pBqRx) {
-                    DeviceFPGA_RxTlp_QueueUserCallback(ctx, (SIZE_T)cdwTlp << 2, pbTlp);
+                    DeviceFPGA_RxTlp_QueueUserCallback(ctx, (SIZE_T)TlpFrame.cdwTlp << 2, pbTlp);
                 }
                 if(ctx->hRxTlpCallbackFn) {
-                    ctx->hRxTlpCallbackFn(ctx->pMRdBufferX, pbTlp, cdwTlp << 2);
+                    ctx->hRxTlpCallbackFn(ctx->pMRdBufferX, pbTlp, TlpFrame.cdwTlp << 2);
                 }
                 pdwData[iStartWord] = pdwData[iStartWord] | (0xffffffff >> (28 - (j << 2)));
                 return iStartWord;

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -1,0 +1,150 @@
+// device_fpga_session.c : internal FPGA session protocol helpers.
+//
+#include "device_fpga_session.h"
+
+#include <string.h>
+
+#define DEVICE_FPGA_CMD_VERSION_MAJOR       0x01
+#define DEVICE_FPGA_CMD_DEVICE_ID           0x03
+#define DEVICE_FPGA_CMD_VERSION_MINOR       0x05
+#define DEVICE_FPGA_V4_IDENTITY_ATTEMPTS    5
+
+static DWORD DeviceFPGA_Session_ReadDWORD(_In_reads_(sizeof(DWORD)) PBYTE pb)
+{
+    DWORD dw;
+    memcpy(&dw, pb, sizeof(dw));
+    return dw;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ParseConfigReply(
+    _In_reads_(cbReply) PBYTE pbReply,
+    _In_ DWORD cbReply,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cbResult) PBYTE pbResult,
+    _In_ WORD cbResult,
+    _In_ WORD flags
+)
+{
+    BOOL fSourceMatch;
+    BYTE pbStaged[0x1000] = { 0 };
+    BYTE pbCovered[0x1000] = { 0 };
+    DWORD i, j, dwStatus, dwData;
+    WORD wAddr;
+    if(!pbResult || !cbResult || (wBaseAddr + cbResult > 0x1000)) { return FALSE; }
+    ZeroMemory(pbResult, cbResult);
+    if(!pbReply || (cbReply < 32)) { return FALSE; }
+    for(i = 0; i + 32 <= cbReply; i += 32) {
+        while((i + sizeof(DWORD) <= cbReply) &&
+              (DeviceFPGA_Session_ReadDWORD(pbReply + i) == 0x55556666)) {
+            i += sizeof(DWORD);
+        }
+        if(i + 32 > cbReply) { return FALSE; }
+        dwStatus = DeviceFPGA_Session_ReadDWORD(pbReply + i);
+        if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
+        for(j = 0; j < 7; j++) {
+            fSourceMatch = (dwStatus & 0x0f) == (DWORD)(flags & 0x03);
+            dwData = DeviceFPGA_Session_ReadDWORD(pbReply + i + 4 + (j * 4));
+            dwStatus >>= 4;
+            if(!fSourceMatch) { continue; }
+            wAddr = _byteswap_ushort((WORD)dwData);
+            wAddr -= (flags & 0xC000) + wBaseAddr;
+            if(wAddr == 0xffff) {
+                pbStaged[0] = (BYTE)(dwData >> 24);
+                pbCovered[0] = TRUE;
+                continue;
+            }
+            if(wAddr >= cbResult) { continue; }
+            pbStaged[wAddr] = (BYTE)(dwData >> 16);
+            pbCovered[wAddr] = TRUE;
+            if(wAddr < cbResult - 1) {
+                pbStaged[wAddr + 1] = (BYTE)(dwData >> 24);
+                pbCovered[wAddr + 1] = TRUE;
+            }
+        }
+    }
+    for(i = 0; i < cbResult; i++) {
+        if(!pbCovered[i]) { return FALSE; }
+    }
+    memcpy(pbResult, pbStaged, cbResult);
+    return TRUE;
+}
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadV4Identity(
+    _In_ PVOID pvContext,
+    _In_ PFN_DEVICE_FPGA_SESSION_CONFIG_READ pfnConfigRead,
+    _In_ WORD flags,
+    _Out_ PDEVICE_FPGA_IDENTITY pIdentity
+)
+{
+    BYTE pbIdentity[3];
+    DWORD i;
+    DEVICE_FPGA_IDENTITY Identity;
+    if(!pfnConfigRead || !pIdentity) { return FALSE; }
+    for(i = 0; i < DEVICE_FPGA_V4_IDENTITY_ATTEMPTS; i++) {
+        ZeroMemory(pbIdentity, sizeof(pbIdentity));
+        if(!pfnConfigRead(pvContext, 0x0008, pbIdentity, sizeof(pbIdentity), flags)) {
+            continue;
+        }
+        if(pbIdentity[0] < 4) { return FALSE; }
+        Identity.wVersionMajor = pbIdentity[0];
+        Identity.wVersionMinor = pbIdentity[1];
+        Identity.wFpgaID = pbIdentity[2];
+        *pIdentity = Identity;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ParseV3Identity(
+    _In_reads_(cbReply) PBYTE pbReply,
+    _In_ DWORD cbReply,
+    _Out_ PDEVICE_FPGA_IDENTITY pIdentity,
+    _Out_ PWORD pwPcieDeviceId
+)
+{
+    BOOL fMajor = FALSE, fMinor = FALSE, fFpgaID = FALSE;
+    DWORD i, j, dwStatus, dwData, cdwCfg = 0;
+    WORD wPcieDeviceId = 0;
+    DEVICE_FPGA_IDENTITY Identity = { 0 };
+    if(!pbReply || !pIdentity || !pwPcieDeviceId || (cbReply < 32)) { return FALSE; }
+    for(i = 0; i + 32 <= cbReply; i += 32) {
+        while((i + sizeof(DWORD) <= cbReply) &&
+              (DeviceFPGA_Session_ReadDWORD(pbReply + i) == 0x55556666)) {
+            i += sizeof(DWORD);
+        }
+        if(i + 32 > cbReply) { return FALSE; }
+        dwStatus = DeviceFPGA_Session_ReadDWORD(pbReply + i);
+        if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
+        for(j = 0; j < 7; j++) {
+            dwData = DeviceFPGA_Session_ReadDWORD(pbReply + i + 4 + (j * 4));
+            if((dwStatus & 0x03) == 0x03) {
+                switch(dwData >> 24) {
+                    case DEVICE_FPGA_CMD_VERSION_MAJOR:
+                        Identity.wVersionMajor = (WORD)dwData;
+                        fMajor = TRUE;
+                        break;
+                    case DEVICE_FPGA_CMD_VERSION_MINOR:
+                        Identity.wVersionMinor = (WORD)dwData;
+                        fMinor = TRUE;
+                        break;
+                    case DEVICE_FPGA_CMD_DEVICE_ID:
+                        Identity.wFpgaID = (WORD)dwData;
+                        fFpgaID = TRUE;
+                        break;
+                }
+            }
+            if((dwStatus & 0x03) == 0x01) {
+                if(((++cdwCfg % 2) == 0) && (WORD)dwData) {
+                    wPcieDeviceId = (WORD)dwData;
+                }
+            }
+            dwStatus >>= 4;
+        }
+    }
+    if(!fMajor || !fMinor || !fFpgaID) { return FALSE; }
+    *pIdentity = Identity;
+    *pwPcieDeviceId = wPcieDeviceId;
+    return TRUE;
+}

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -16,6 +16,55 @@ static DWORD DeviceFPGA_Session_ReadDWORD(_In_reads_(sizeof(DWORD)) PBYTE pb)
     return dw;
 }
 
+#ifndef LINUX
+DEVICE_FPGA_SESSION_TLP_FRAME_ACTION DeviceFPGA_Session_TlpFrameStep(
+    _Inout_ PDEVICE_FPGA_SESSION_TLP_FRAME_STATE pState,
+    _In_ BYTE bStatus,
+    _In_ DWORD cdwMax
+)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_ACTION Action;
+    if(!pState || !cdwMax) {
+        return DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED;
+    }
+    bStatus &= 0x0f;
+    if(bStatus & 0x03) {
+        return DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE;
+    }
+    if(bStatus & 0x08) {
+        Action = pState->fInTlp ?
+            DEVICE_FPGA_SESSION_TLP_FRAME_RESTART :
+            DEVICE_FPGA_SESSION_TLP_FRAME_APPEND;
+        pState->fInTlp = TRUE;
+        pState->cdwTlp = 0;
+    } else {
+        if(!pState->fInTlp) {
+            if(pState->fRequireFirst) {
+                return DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE;
+            }
+            pState->fInTlp = TRUE;
+            pState->cdwTlp = 0;
+        }
+        Action = DEVICE_FPGA_SESSION_TLP_FRAME_APPEND;
+    }
+    if(pState->cdwTlp >= cdwMax) {
+        pState->fInTlp = FALSE;
+        pState->cdwTlp = 0;
+        return DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED;
+    }
+    pState->cdwTlp++;
+    if(bStatus & 0x04) {
+        pState->fInTlp = FALSE;
+        if(pState->cdwTlp < 3) {
+            pState->cdwTlp = 0;
+            return DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED;
+        }
+        return DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE;
+    }
+    return Action;
+}
+#endif /* LINUX */
+
 _Success_(return)
 BOOL DeviceFPGA_Session_ParseConfigReply(
     _In_reads_(cbReply) PBYTE pbReply,

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -19,6 +19,77 @@ typedef BOOL(*PFN_DEVICE_FPGA_SESSION_CONFIG_READ)(
     _In_ WORD flags
 );
 
+typedef enum tdDEVICE_FPGA_SESSION_TLP_FRAME_ACTION {
+    DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE = 0,
+    DEVICE_FPGA_SESSION_TLP_FRAME_APPEND,
+    DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE,
+    DEVICE_FPGA_SESSION_TLP_FRAME_RESTART,
+    DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED
+} DEVICE_FPGA_SESSION_TLP_FRAME_ACTION;
+
+typedef struct tdDEVICE_FPGA_SESSION_TLP_FRAME_STATE {
+    BOOL fRequireFirst;
+    BOOL fInTlp;
+    DWORD cdwTlp;
+} DEVICE_FPGA_SESSION_TLP_FRAME_STATE, *PDEVICE_FPGA_SESSION_TLP_FRAME_STATE;
+
+#ifdef LINUX
+static __inline__ __attribute__((always_inline))
+DEVICE_FPGA_SESSION_TLP_FRAME_ACTION
+DeviceFPGA_Session_TlpFrameStep(
+    _Inout_ PDEVICE_FPGA_SESSION_TLP_FRAME_STATE pState,
+    _In_ BYTE bStatus,
+    _In_ DWORD cdwMax
+)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_ACTION Action;
+    if(!pState || !cdwMax) {
+        return DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED;
+    }
+    bStatus &= 0x0f;
+    if(bStatus & 0x03) {
+        return DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE;
+    }
+    if(bStatus & 0x08) {
+        Action = pState->fInTlp ?
+            DEVICE_FPGA_SESSION_TLP_FRAME_RESTART :
+            DEVICE_FPGA_SESSION_TLP_FRAME_APPEND;
+        pState->fInTlp = TRUE;
+        pState->cdwTlp = 0;
+    } else {
+        if(!pState->fInTlp) {
+            if(pState->fRequireFirst) {
+                return DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE;
+            }
+            pState->fInTlp = TRUE;
+            pState->cdwTlp = 0;
+        }
+        Action = DEVICE_FPGA_SESSION_TLP_FRAME_APPEND;
+    }
+    if(pState->cdwTlp >= cdwMax) {
+        pState->fInTlp = FALSE;
+        pState->cdwTlp = 0;
+        return DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED;
+    }
+    pState->cdwTlp++;
+    if(bStatus & 0x04) {
+        pState->fInTlp = FALSE;
+        if(pState->cdwTlp < 3) {
+            pState->cdwTlp = 0;
+            return DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED;
+        }
+        return DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE;
+    }
+    return Action;
+}
+#else
+DEVICE_FPGA_SESSION_TLP_FRAME_ACTION DeviceFPGA_Session_TlpFrameStep(
+    _Inout_ PDEVICE_FPGA_SESSION_TLP_FRAME_STATE pState,
+    _In_ BYTE bStatus,
+    _In_ DWORD cdwMax
+);
+#endif /* LINUX */
+
 _Success_(return)
 BOOL DeviceFPGA_Session_ParseConfigReply(
     _In_reads_(cbReply) PBYTE pbReply,

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -1,0 +1,48 @@
+// device_fpga_session.h : internal FPGA session protocol helpers.
+//
+#ifndef __DEVICE_FPGA_SESSION_H__
+#define __DEVICE_FPGA_SESSION_H__
+
+#include "oscompatibility.h"
+
+typedef struct tdDEVICE_FPGA_IDENTITY {
+    WORD wVersionMajor;
+    WORD wVersionMinor;
+    WORD wFpgaID;
+} DEVICE_FPGA_IDENTITY, *PDEVICE_FPGA_IDENTITY;
+
+typedef BOOL(*PFN_DEVICE_FPGA_SESSION_CONFIG_READ)(
+    _In_ PVOID pvContext,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cb) PBYTE pb,
+    _In_ WORD cb,
+    _In_ WORD flags
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ParseConfigReply(
+    _In_reads_(cbReply) PBYTE pbReply,
+    _In_ DWORD cbReply,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cbResult) PBYTE pbResult,
+    _In_ WORD cbResult,
+    _In_ WORD flags
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadV4Identity(
+    _In_ PVOID pvContext,
+    _In_ PFN_DEVICE_FPGA_SESSION_CONFIG_READ pfnConfigRead,
+    _In_ WORD flags,
+    _Out_ PDEVICE_FPGA_IDENTITY pIdentity
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ParseV3Identity(
+    _In_reads_(cbReply) PBYTE pbReply,
+    _In_ DWORD cbReply,
+    _Out_ PDEVICE_FPGA_IDENTITY pIdentity,
+    _Out_ PWORD pwPcieDeviceId
+);
+
+#endif /* __DEVICE_FPGA_SESSION_H__ */

--- a/leechcore/leechcore.vcxproj
+++ b/leechcore/leechcore.vcxproj
@@ -352,6 +352,7 @@ copy "$(ProjectDir)\leechcore.h" "$(SolutionDir)\includes\" /y
     <ClCompile Include="charutil.c" />
     <ClCompile Include="device_file.c" />
     <ClCompile Include="device_fpga.c" />
+    <ClCompile Include="device_fpga_session.c" />
     <ClCompile Include="device_hibr.c" />
     <ClCompile Include="device_pmem.c" />
     <ClCompile Include="device_tmd.c" />
@@ -372,6 +373,7 @@ copy "$(ProjectDir)\leechcore.h" "$(SolutionDir)\includes\" /y
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="charutil.h" />
+    <ClInclude Include="device_fpga_session.h" />
     <ClInclude Include="leechcore.h" />
     <ClInclude Include="leechcore_device.h" />
     <ClInclude Include="leechcore_internal.h" />

--- a/leechcore/leechcore.vcxproj.filters
+++ b/leechcore/leechcore.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="device_fpga.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="device_fpga_session.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="device_pmem.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -111,6 +114,9 @@
       <Filter>Header Files\ob</Filter>
     </ClInclude>
     <ClInclude Include="charutil.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="device_fpga_session.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all clean linux-codegen-check
+
+all: linux-codegen-check
+
+linux-codegen-check:
+	bash ./check_linux_fpga_session_codegen.sh
+
+clean:

--- a/tests/check_linux_fpga_session_codegen.sh
+++ b/tests/check_linux_fpga_session_codegen.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+work=$(mktemp -d)
+object="$work/device_fpga.o"
+
+gcc -c "$root/leechcore/device_fpga.c" \
+    -I"$root/leechcore" -I"$root/includes" \
+    -D LINUX -D _GNU_SOURCE \
+    -O1 -fPIC -Wall -Wno-multichar -Wno-unused-variable \
+    $(pkg-config libusb-1.0 --cflags) \
+    -o "$object"
+
+if nm -u "$object" |
+    grep -q 'DeviceFPGA_Session_TlpFrameStep'; then
+    echo "unexpected external Linux framing call" >&2
+    exit 1
+fi
+echo "PASS: Linux framing transition is inline"

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -1,0 +1,297 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../leechcore/device_fpga_session.h"
+
+static int g_cFailures = 0;
+
+#define ASSERT_TRUE(value) \
+    do { \
+        if(!(value)) { \
+            printf("FAIL %s:%d: expected true\n", __FILE__, __LINE__); \
+            g_cFailures++; \
+        } \
+    } while(0)
+
+#define ASSERT_FALSE(value) \
+    do { \
+        if(value) { \
+            printf("FAIL %s:%d: expected false\n", __FILE__, __LINE__); \
+            g_cFailures++; \
+        } \
+    } while(0)
+
+#define ASSERT_EQ(actual, expected) \
+    do { \
+        if((actual) != (expected)) { \
+            printf("FAIL %s:%d: expected %lu, got %lu\n", \
+                __FILE__, __LINE__, \
+                (unsigned long)(expected), (unsigned long)(actual)); \
+            g_cFailures++; \
+        } \
+    } while(0)
+
+static VOID AssertBytes(
+    _In_reads_(cbActual) PBYTE pbActual,
+    _In_reads_(cbActual) PBYTE pbExpected,
+    _In_ DWORD cbActual,
+    _In_ DWORD line
+)
+{
+    DWORD i;
+    if(!memcmp(pbActual, pbExpected, cbActual)) { return; }
+    printf("FAIL %s:%lu: byte mismatch:", __FILE__, (unsigned long)line);
+    for(i = 0; i < cbActual; i++) {
+        printf(" %02x/%02x", pbActual[i], pbExpected[i]);
+    }
+    printf("\n");
+    g_cFailures++;
+}
+
+#define ASSERT_BYTES(actual, expected, count) \
+    AssertBytes((actual), (expected), (count), __LINE__)
+
+static VOID TestCompleteAlignedReply(VOID)
+{
+    BYTE pbReply[32] = {
+        0x33, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x04, 0x13,
+        0x00, 0x0a, 0x04, 0x00
+    };
+    BYTE pbActual[3] = { 0xaa, 0xbb, 0xcc };
+    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
+    ASSERT_TRUE(DeviceFPGA_Session_ParseConfigReply(
+        pbReply, sizeof(pbReply), 0x0008, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+static VOID TestCompleteUnalignedReply(VOID)
+{
+    BYTE pbReply[32] = {
+        0x03, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x04, 0x13
+    };
+    BYTE pbActual[1] = { 0xaa };
+    BYTE pbExpected[1] = { 0x13 };
+    ASSERT_TRUE(DeviceFPGA_Session_ParseConfigReply(
+        pbReply, sizeof(pbReply), 0x0009, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+static VOID TestCompleteZeroValuedReply(VOID)
+{
+    BYTE pbReply[32] = {
+        0x33, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x00, 0x00,
+        0x00, 0x0a, 0x00, 0x00
+    };
+    BYTE pbActual[3] = { 0xaa, 0xbb, 0xcc };
+    BYTE pbExpected[3] = { 0x00, 0x00, 0x00 };
+    ASSERT_TRUE(DeviceFPGA_Session_ParseConfigReply(
+        pbReply, sizeof(pbReply), 0x0008, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+static VOID TestEmptyReplyFailsAndClearsOutput(VOID)
+{
+    BYTE pbActual[3] = { 0xaa, 0xbb, 0xcc };
+    BYTE pbExpected[3] = { 0x00, 0x00, 0x00 };
+    ASSERT_FALSE(DeviceFPGA_Session_ParseConfigReply(
+        NULL, 0, 0x0008, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+static VOID TestPartialReplyFailsAndClearsOutput(VOID)
+{
+    BYTE pbReply[32] = {
+        0x03, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x04, 0x13
+    };
+    BYTE pbActual[3] = { 0xaa, 0xbb, 0xcc };
+    BYTE pbExpected[3] = { 0x00, 0x00, 0x00 };
+    ASSERT_FALSE(DeviceFPGA_Session_ParseConfigReply(
+        pbReply, sizeof(pbReply), 0x0008, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+static VOID TestWrongSourceReplyFailsAndClearsOutput(VOID)
+{
+    BYTE pbReply[32] = {
+        0x11, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x04, 0x13,
+        0x00, 0x0a, 0x04, 0x00
+    };
+    BYTE pbActual[3] = { 0xaa, 0xbb, 0xcc };
+    BYTE pbExpected[3] = { 0x00, 0x00, 0x00 };
+    ASSERT_FALSE(DeviceFPGA_Session_ParseConfigReply(
+        pbReply, sizeof(pbReply), 0x0008, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+typedef struct tdCONFIG_READ_SCRIPT {
+    DWORD cCalls;
+    DWORD cFailures;
+    BYTE pbIdentity[3];
+    BOOL fUnexpectedArguments;
+} CONFIG_READ_SCRIPT, *PCONFIG_READ_SCRIPT;
+
+static BOOL ScriptedConfigRead(
+    _In_ PVOID pvContext,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cb) PBYTE pb,
+    _In_ WORD cb,
+    _In_ WORD flags
+)
+{
+    PCONFIG_READ_SCRIPT pScript = (PCONFIG_READ_SCRIPT)pvContext;
+    pScript->cCalls++;
+    if((wBaseAddr != 0x0008) || (cb != 3) || (flags != 0x0003)) {
+        pScript->fUnexpectedArguments = TRUE;
+        return FALSE;
+    }
+    if(pScript->cCalls <= pScript->cFailures) {
+        ZeroMemory(pb, cb);
+        return FALSE;
+    }
+    memcpy(pb, pScript->pbIdentity, cb);
+    return TRUE;
+}
+
+static VOID AssertIdentity(
+    _In_ PDEVICE_FPGA_IDENTITY pIdentity,
+    _In_ WORD wVersionMajor,
+    _In_ WORD wVersionMinor,
+    _In_ WORD wFpgaID,
+    _In_ DWORD line
+)
+{
+    if((pIdentity->wVersionMajor == wVersionMajor) &&
+       (pIdentity->wVersionMinor == wVersionMinor) &&
+       (pIdentity->wFpgaID == wFpgaID)) {
+        return;
+    }
+    printf(
+        "FAIL %s:%lu: expected identity %u.%u id %u, got %u.%u id %u\n",
+        __FILE__,
+        (unsigned long)line,
+        wVersionMajor,
+        wVersionMinor,
+        wFpgaID,
+        pIdentity->wVersionMajor,
+        pIdentity->wVersionMinor,
+        pIdentity->wFpgaID);
+    g_cFailures++;
+}
+
+#define ASSERT_IDENTITY(identity, major, minor, id) \
+    AssertIdentity(&(identity), (major), (minor), (id), __LINE__)
+
+static VOID TestV4IdentityRetriesAndPublishesCompleteReply(VOID)
+{
+    CONFIG_READ_SCRIPT Script = { 0, 1, { 4, 19, 4 }, FALSE };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    ASSERT_TRUE(DeviceFPGA_Session_ReadV4Identity(
+        &Script, ScriptedConfigRead, 0x0003, &Identity));
+    ASSERT_FALSE(Script.fUnexpectedArguments);
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_IDENTITY(Identity, 4, 19, 4);
+}
+
+static VOID TestV4IdentityFailureIsBoundedAndDoesNotPublish(VOID)
+{
+    CONFIG_READ_SCRIPT Script = { 0, 10, { 4, 19, 4 }, FALSE };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    ASSERT_FALSE(DeviceFPGA_Session_ReadV4Identity(
+        &Script, ScriptedConfigRead, 0x0003, &Identity));
+    ASSERT_FALSE(Script.fUnexpectedArguments);
+    ASSERT_EQ(Script.cCalls, 5);
+    ASSERT_IDENTITY(Identity, 0xaa, 0xbb, 0xcc);
+}
+
+static VOID TestV4IdentityAcceptsExplicitZeroFpgaId(VOID)
+{
+    CONFIG_READ_SCRIPT Script = { 0, 0, { 4, 19, 0 }, FALSE };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    ASSERT_TRUE(DeviceFPGA_Session_ReadV4Identity(
+        &Script, ScriptedConfigRead, 0x0003, &Identity));
+    ASSERT_IDENTITY(Identity, 4, 19, 0);
+}
+
+static VOID TestV4IdentityRejectsLegacyMajorWithoutPublishing(VOID)
+{
+    CONFIG_READ_SCRIPT Script = { 0, 0, { 3, 7, 4 }, FALSE };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    ASSERT_FALSE(DeviceFPGA_Session_ReadV4Identity(
+        &Script, ScriptedConfigRead, 0x0003, &Identity));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_IDENTITY(Identity, 0xaa, 0xbb, 0xcc);
+}
+
+static VOID TestV3IdentityRequiresEveryIdentityCommand(VOID)
+{
+    BYTE pbReply[32] = {
+        0x33, 0x00, 0x00, 0xe0,
+        0x04, 0x00, 0x00, 0x01,
+        0x13, 0x00, 0x00, 0x05
+    };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    WORD wPcieDeviceId = 0xdddd;
+    ASSERT_FALSE(DeviceFPGA_Session_ParseV3Identity(
+        pbReply, sizeof(pbReply), &Identity, &wPcieDeviceId));
+    ASSERT_IDENTITY(Identity, 0xaa, 0xbb, 0xcc);
+    ASSERT_EQ(wPcieDeviceId, 0xdddd);
+}
+
+static VOID TestV3IdentityPublishesCompleteReply(VOID)
+{
+    BYTE pbReply[32] = {
+        0x33, 0x03, 0x00, 0xe0,
+        0x04, 0x00, 0x00, 0x01,
+        0x13, 0x00, 0x00, 0x05,
+        0x04, 0x00, 0x00, 0x03
+    };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    WORD wPcieDeviceId = 0xdddd;
+    ASSERT_TRUE(DeviceFPGA_Session_ParseV3Identity(
+        pbReply, sizeof(pbReply), &Identity, &wPcieDeviceId));
+    ASSERT_IDENTITY(Identity, 4, 19, 4);
+    ASSERT_EQ(wPcieDeviceId, 0);
+}
+
+static VOID TestV3IdentityAcceptsExplicitZeroFpgaId(VOID)
+{
+    BYTE pbReply[32] = {
+        0x33, 0x03, 0x00, 0xe0,
+        0x04, 0x00, 0x00, 0x01,
+        0x13, 0x00, 0x00, 0x05,
+        0x00, 0x00, 0x00, 0x03
+    };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    WORD wPcieDeviceId = 0xdddd;
+    ASSERT_TRUE(DeviceFPGA_Session_ParseV3Identity(
+        pbReply, sizeof(pbReply), &Identity, &wPcieDeviceId));
+    ASSERT_IDENTITY(Identity, 4, 19, 0);
+}
+
+int main(void)
+{
+    TestCompleteAlignedReply();
+    TestCompleteUnalignedReply();
+    TestCompleteZeroValuedReply();
+    TestEmptyReplyFailsAndClearsOutput();
+    TestPartialReplyFailsAndClearsOutput();
+    TestWrongSourceReplyFailsAndClearsOutput();
+    TestV4IdentityRetriesAndPublishesCompleteReply();
+    TestV4IdentityFailureIsBoundedAndDoesNotPublish();
+    TestV4IdentityAcceptsExplicitZeroFpgaId();
+    TestV4IdentityRejectsLegacyMajorWithoutPublishing();
+    TestV3IdentityRequiresEveryIdentityCommand();
+    TestV3IdentityPublishesCompleteReply();
+    TestV3IdentityAcceptsExplicitZeroFpgaId();
+    if(g_cFailures) {
+        printf("%d test assertion(s) failed.\n", g_cFailures);
+        return 1;
+    }
+    printf("PASS: 13 FPGA identity protocol cases.\n");
+    return 0;
+}

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -273,6 +273,89 @@ static VOID TestV3IdentityAcceptsExplicitZeroFpgaId(VOID)
     ASSERT_IDENTITY(Identity, 4, 19, 0);
 }
 
+static VOID TestTlpFrameIgnoresContinuationUntilFirst(VOID)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE State = { TRUE, FALSE, 0 };
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x00, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE);
+    ASSERT_FALSE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 0);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x04, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE);
+    ASSERT_FALSE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 0);
+}
+
+static VOID TestTlpFrameCompletesAfterExplicitFirst(VOID)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE State = { TRUE, FALSE, 0 };
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x08, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x00, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x04, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE);
+    ASSERT_FALSE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 3);
+}
+
+static VOID TestTlpFrameRestartsAtNewFirst(VOID)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE State = { TRUE, FALSE, 0 };
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x08, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x00, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x08, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_RESTART);
+    ASSERT_TRUE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 1);
+}
+
+static VOID TestTlpFrameRejectsShortAndOversizePackets(VOID)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE State = { TRUE, FALSE, 0 };
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x0c, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED);
+    ASSERT_FALSE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 0);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x08, 1),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x00, 1),
+        DEVICE_FPGA_SESSION_TLP_FRAME_MALFORMED);
+    ASSERT_FALSE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 0);
+}
+
+static VOID TestTlpFrameAcceptsLegacyStreamWithoutFirst(VOID)
+{
+    DEVICE_FPGA_SESSION_TLP_FRAME_STATE State = { FALSE, FALSE, 0 };
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x00, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_TRUE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 1);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x00, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_APPEND);
+    ASSERT_EQ(
+        DeviceFPGA_Session_TlpFrameStep(&State, 0x04, 260),
+        DEVICE_FPGA_SESSION_TLP_FRAME_COMPLETE);
+    ASSERT_FALSE(State.fInTlp);
+    ASSERT_EQ(State.cdwTlp, 3);
+}
+
 int main(void)
 {
     TestCompleteAlignedReply();
@@ -288,10 +371,15 @@ int main(void)
     TestV3IdentityRequiresEveryIdentityCommand();
     TestV3IdentityPublishesCompleteReply();
     TestV3IdentityAcceptsExplicitZeroFpgaId();
+    TestTlpFrameIgnoresContinuationUntilFirst();
+    TestTlpFrameCompletesAfterExplicitFirst();
+    TestTlpFrameRestartsAtNewFirst();
+    TestTlpFrameRejectsShortAndOversizePackets();
+    TestTlpFrameAcceptsLegacyStreamWithoutFirst();
     if(g_cFailures) {
         printf("%d test assertion(s) failed.\n", g_cFailures);
         return 1;
     }
-    printf("PASS: 13 FPGA identity protocol cases.\n");
+    printf("PASS: 18 FPGA identity and framing protocol cases.\n");
     return 0;
 }

--- a/tests/device_fpga_session_test.vcxproj
+++ b/tests/device_fpga_session_test.vcxproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7C4E1F2A-93B6-4D58-9A0E-2F5C81D4A6B3}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>device_fpga_session_test</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <OutDir>$(ProjectDir)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>device_fpga_session_test</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <DisableSpecificWarnings>4200;4201;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\leechcore;$(ProjectDir)..\includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="device_fpga_session_test.c" />
+    <ClCompile Include="..\leechcore\device_fpga_session.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>


### PR DESCRIPTION
## Summary

Firmware 4.13 can emit a `FIRST` marker while a previous TLP frame is still being assembled. Treating that marker only as a start-of-buffer hint can merge or discard frames.

This change makes `FIRST` an explicit framing transition, preserves compatibility with older firmware, and retains the narrow in-frame continuation fast path where it is safe. The transition remains inline in the Linux production build.

## Verification

- 18 deterministic identity and framing protocol cases pass on Windows x64 and Win32.
- Linux code-generation validation confirms the framing transition remains inline.
- The combined rollup passes the complete Windows and Linux validation matrix.

Contribution offered under the 0BSD license.

Review dependency: this builds on *fix(fpga): validate FT601 identity initialization*, and the diff below includes that change along with any earlier ones in the series. It branches from the same prerequisite as *fix(fpga): bound FT601 pipe and teardown waits* and can be taken independently of it; taking both leaves a small textual merge on whichever lands second, since both add declarations to `device_fpga_session.h` and cases to the session test. Merge the series in dependency order, or take the combined rollup instead.

