### PR TITLE
fix(fpga): avoid aborting unused FT601 pipes on open

### DIFF
--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -896,8 +896,6 @@ ftdi_retry_old:
             }
             goto fail;
         }
-        ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x02);
-        ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82);
         pfnFT_SetSuspendTimeout(ctx->dev.hFTDI, 0);
         // Check FTDI chip configuration and update if required
         status = pfnFT_GetChipConfiguration(ctx->dev.hFTDI, &oCfgOld);


### PR DESCRIPTION
## Summary

Fresh FT601 handles were aborting both pipes immediately after open even though no transfer had been submitted. That can disturb a clean device session without recovering any outstanding work.

This change removes the unnecessary open-time abort. Abort remains available where active or interrupted work actually needs recovery.

## Verification

- Full LeechCore Release builds pass warning-free for Windows x64 and x86.

Contribution offered under the 0BSD license.

Review dependency: none. This change branches from master, is independent of the rest of the series, and can be merged at any point. It is also included in the combined rollup.
