### PR TITLE
fix(fpga): isolate PCIe config replies per batch

### DIFF
--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -237,14 +237,11 @@ typedef ULONG(WINAPI *PFN_FT_AbortPipe)(HANDLE ftHandle, UCHAR ucPipeID);
 typedef ULONG(WINAPI *PFN_FT_GetOverlappedResult)(HANDLE ftHandle, LPOVERLAPPED pOverlapped, PULONG pulLengthTransferred, BOOL bWait);
 typedef ULONG(WINAPI *PFN_FT_InitializeOverlapped)(HANDLE ftHandle, LPOVERLAPPED pOverlapped);
 typedef ULONG(WINAPI *PFN_FT_ReleaseOverlapped)(HANDLE ftHandle, LPOVERLAPPED pOverlapped);
-typedef ULONG(WINAPI *PFN_FT_SetPipeTimeout)(HANDLE ftHandle, UCHAR ucPipeID, ULONG ulTimeoutInMs);
-
 typedef struct tdDEVICE_CONTEXT_FPGA {
     CRITICAL_SECTION Lock;
     BOOL fTransportUsable;
     BOOL fTransportSetup;
     BOOL fTransportRecoveryInProgress;
-    BOOL fOpenPipeTimeoutFailure;
     BOOL fAdaptivePollingWait;  // disable event waits after sustained issued completion loss
     DWORD dwAdaptivePollingGeneration;
     DWORD dwTransportGeneration;
@@ -297,7 +294,6 @@ typedef struct tdDEVICE_CONTEXT_FPGA {
         PFN_FT_GetOverlappedResult pfnFT_GetOverlappedResult;
         PFN_FT_InitializeOverlapped pfnFT_InitializeOverlapped;
         PFN_FT_ReleaseOverlapped pfnFT_ReleaseOverlapped;
-        PFN_FT_SetPipeTimeout pfnFT_SetPipeTimeout;
     } dev;
     FPGA_NEWASYNC2_CONTEXT async2;
     PVOID pMRdBufferX; // NULL || PFPGA_PROBE_CALLBACK || PTLP_CALLBACK_BUF_MRd_SCATTER
@@ -974,7 +970,6 @@ ftdi_retry_old:
     ctx->dev.pfnFT_GetOverlappedResult = (PFN_FT_GetOverlappedResult)GetProcAddress(ctx->dev.hModule, "FT_GetOverlappedResult");
     ctx->dev.pfnFT_InitializeOverlapped = (PFN_FT_InitializeOverlapped)GetProcAddress(ctx->dev.hModule, "FT_InitializeOverlapped");
     ctx->dev.pfnFT_ReleaseOverlapped = (PFN_FT_ReleaseOverlapped)GetProcAddress(ctx->dev.hModule, "FT_ReleaseOverlapped");
-    ctx->dev.pfnFT_SetPipeTimeout = (PFN_FT_SetPipeTimeout)GetProcAddress(ctx->dev.hModule, "FT_SetPipeTimeout");
     pfnFT_GetChipConfiguration = (ULONG(WINAPI*)(HANDLE, PVOID))GetProcAddress(ctx->dev.hModule, "FT_GetChipConfiguration");
     pfnFT_SetChipConfiguration = (ULONG(WINAPI*)(HANDLE, PVOID))GetProcAddress(ctx->dev.hModule, "FT_SetChipConfiguration");
     pfnFT_SetSuspendTimeout = (ULONG(WINAPI*)(HANDLE, ULONG))GetProcAddress(ctx->dev.hModule, "FT_SetSuspendTimeout");
@@ -991,7 +986,7 @@ ftdi_retry_old:
             fFailFTD3XXWU = fUseFTD3XXWU;
 #endif /* _WIN32 */
             if(!szErrorReason) {
-                szErrorReason = ctx->fOpenPipeTimeoutFailure ? "Unable to configure FT601 pipe timeouts" : "Unable to connect to FPGA device";
+                szErrorReason = "Unable to connect to FPGA device";
             }
             goto fail;
         }
@@ -1252,7 +1247,6 @@ static BOOL DeviceFPGA_OpenFTDIHandle(_Inout_ PDEVICE_CONTEXT_FPGA ctx)
 {
     HANDLE hFTDI = NULL;
     DWORD status;
-    ctx->fOpenPipeTimeoutFailure = FALSE;
     if(!ctx->dev.pfnFT_Create || ctx->dev.hFTDI) { return FALSE; }
     status = ctx->dev.pfnFT_Create((PVOID)ctx->qwDeviceIndex, 0x10 /*FT_OPEN_BY_INDEX*/, &hFTDI);
     if(status || !hFTDI) {
@@ -1397,9 +1391,22 @@ BOOL DeviceFPGA_ConfigRead(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, _
     }
     Sleep(10);
     // READ and interpret result
-    status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, pbRxTx, 0x20000, &cbRxTx, NULL);
-    if(status) { goto fail; }
-    fReturn = DeviceFPGA_Session_ParseConfigReply(pbRxTx, cbRxTx, wBaseAddr, pb, cb, flags);
+    if(!DeviceFPGA_Session_ReadConfigReplyMatching(
+        ctx->dev.hFTDI,
+        pbRxTx,
+        0x20000,
+        &cbRxTx,
+        ctx->dev.pfnFT_ReadPipe,
+        wBaseAddr,
+        pb,
+        cb,
+        flags,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL)) {
+        goto fail;
+    }
+    fReturn = TRUE;
 fail:
     LocalFree(pbRxTx);
     return fReturn;
@@ -1489,6 +1496,65 @@ BOOL DeviceFPGA_ConfigWrite(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, 
     return TRUE;
 }
 
+typedef struct tdDEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT {
+    PDEVICE_CONTEXT_FPGA ctx;
+    DWORD raSingleDW;
+} DEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT, *PDEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT;
+
+static BOOL DeviceFPGA_PCIeCfgSpaceCoreReadAttempt(
+    _Inout_ PVOID pvContext,
+    _Out_writes_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pb
+)
+{
+    PDEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT pReadContext =
+        (PDEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT)pvContext;
+    PDEVICE_CONTEXT_FPGA ctx;
+    BYTE pbRxTx[0x1000], pbCoverage[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    DWORD status, cbRxTx, cBatchDWords, raSingleDW;
+    WORD wDWordAddr;
+    if(!pReadContext || !pReadContext->ctx || !pb) { return FALSE; }
+    ctx = pReadContext->ctx;
+    raSingleDW = pReadContext->raSingleDW;
+    if(!DeviceFPGA_TransportIOAllowed(ctx)) { return FALSE; }
+    ZeroMemory(pbCoverage, sizeof(pbCoverage));
+    // A 32-DWORD reply can cross the FT601's effective 1 KiB receive
+    // boundary and lose its final framed result. Keep each reply below it.
+    for(wDWordAddr = 0;
+        (cBatchDWords = DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+            wDWordAddr, raSingleDW));
+        wDWordAddr = (WORD)(wDWordAddr + cBatchDWords)) {
+        if(!DeviceFPGA_Session_BuildPCIeConfigBatch(
+            pbRxTx,
+            sizeof(pbRxTx),
+            &cbRxTx,
+            wDWordAddr,
+            raSingleDW)) {
+            return FALSE;
+        }
+        // WRITE TxData
+        status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbRxTx, cbRxTx, &cbRxTx, NULL);
+        if(status) { return FALSE; }
+        Sleep(10);
+        if(!DeviceFPGA_Session_ReadConfigReply(
+            ctx->dev.hFTDI,
+            pbRxTx,
+            sizeof(pbRxTx),
+            &cbRxTx,
+            ctx->dev.pfnFT_ReadPipe,
+            DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+            NULL,
+            NULL)) {
+            return FALSE;
+        }
+        if(!DeviceFPGA_Session_ParsePCIeConfigReply(
+            pbRxTx, cbRxTx, pb, pbCoverage)) {
+            return FALSE;
+        }
+        if(raSingleDW) { break; }
+    }
+    return DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, raSingleDW);
+}
+
 /*
 * Read from the device PCIe configuration space. Only the values used by the
 * xilinx ip core itself is read. Custom "shadow" user-provided configuration
@@ -1503,84 +1569,10 @@ BOOL DeviceFPGA_ConfigWrite(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, 
 _Success_(return)
 BOOL DeviceFPGA_PCIeCfgSpaceCoreRead(_In_ PDEVICE_CONTEXT_FPGA ctx, _Out_writes_(0x200) PBYTE pb, _In_opt_ DWORD raSingleDW)
 {
-    BYTE pbTxLockEnable[]   = { 0x04, 0x00, 0x04, 0x00, 0x80, 0x02, 0x21, 0x77 };
-    BYTE pbTxLockDisable[]  = { 0x00, 0x00, 0x04, 0x00, 0x80, 0x02, 0x21, 0x77 };
-    BYTE pbTxReadEnable[]   = { 0x01, 0x00, 0x01, 0x00, 0x80, 0x02, 0x21, 0x77 };
-    BYTE pbTxAddress[]      = { 0x00, 0x00, 0xff, 0x03, 0x80, 0x14, 0x21, 0x77 };
-    BYTE pbTxResultMeta[]   = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a, 0x11, 0x77 };
-    BYTE pbTxResultDataLo[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x2c, 0x11, 0x77 };
-    BYTE pbTxResultDataHi[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x2e, 0x11, 0x77 };
-    BOOL f;
-    BYTE oAddr, pbRxTx[0x1000];
-    DWORD i, j, status, dwStatus, dwData, cbRxTx;
-    PDWORD pdwData;
-    WORD wDWordAddr, oDWord, wAddr = 0;
-    if(!DeviceFPGA_TransportIOAllowed(ctx)) { return FALSE; }
-    ZeroMemory(pb, 0x200);
-    for(wDWordAddr = 0; wDWordAddr < 0x80; wDWordAddr += 32) {  // 0x80 * sizeof(DWORD) == 0x200
-        cbRxTx = 0;
-        for(oDWord = 0; oDWord < 32; oDWord++) {
-            memcpy(pbRxTx + cbRxTx, pbTxLockEnable, 8); cbRxTx += 8;    // enable read/write lock (instruction serialization)
-            // NB! read config space DWORD _TWO_ times on 1st read in
-            //     batch required to clear any lingering register data.
-            for(i = 0; (i < 2) && (!i || !oDWord); i++) {
-                // WRITE request setup (address)
-                if(raSingleDW) {
-                    // set address: single dword read
-                    pbTxAddress[0] = raSingleDW & 0xff;
-                    pbTxAddress[1] = (raSingleDW >> 8) & 0x03;
-                } else {
-                    // set address: normal (full config space read)
-                    pbTxAddress[0] = (wDWordAddr + oDWord) & 0xff;
-                    pbTxAddress[1] = ((wDWordAddr + oDWord) >> 8) & 0x03;
-                }
-                memcpy(pbRxTx + cbRxTx, pbTxAddress, 8); cbRxTx += 8;
-                // WRITE read enable bit
-                memcpy(pbRxTx + cbRxTx, pbTxReadEnable, 8); cbRxTx += 8;
-            }
-            // READ result
-            memcpy(pbRxTx + cbRxTx, pbTxResultMeta, 8); cbRxTx += 8;
-            memcpy(pbRxTx + cbRxTx, pbTxResultDataLo, 8); cbRxTx += 8;
-            memcpy(pbRxTx + cbRxTx, pbTxResultDataHi, 8); cbRxTx += 8;
-            memcpy(pbRxTx + cbRxTx, pbTxLockDisable, 8); cbRxTx += 8;   // disable read/write lock (instruction serialization)
-            if(raSingleDW) { break; }
-        }
-        // WRITE TxData
-        status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbRxTx, cbRxTx, &cbRxTx, NULL);
-        if(status) { return FALSE; }
-        Sleep(10);
-        // READ and interpret result
-        status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, pbRxTx, 0x1000, &cbRxTx, NULL);
-        if(status) { return FALSE; }
-        for(i = 0; i < cbRxTx; i += 32) {
-            while(*(PDWORD)(pbRxTx + i) == 0x55556666) { // skip over ftdi workaround dummy fillers
-                i += 4;
-                if(i + 32 > cbRxTx) { return FALSE; }
-            }
-            dwStatus = *(PDWORD)(pbRxTx + i);
-            pdwData = (PDWORD)(pbRxTx + i + 4);
-            if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
-            for(j = 0; j < 7; j++) {
-                f = (dwStatus & 0x0f) == 0x01;
-                dwData = *pdwData;
-                pdwData++;                              // move ptr to next data
-                dwStatus >>= 4;                         // move to next status
-                if(!f) { continue; }                    // status src flags does not match source
-                if((dwData & 0x0800ffff) == 0x08002a00) {
-                    wAddr = ((dwData >> 16) & 0x03ff) << 2;
-                    continue;
-                }
-                oAddr = (BYTE)(dwData >> 8);
-                if((oAddr != 0x2c) && (oAddr != 0x2e)) { continue; }
-                oAddr -= 0x2c;
-                if(wAddr + oAddr + 1 >= 0x200) { continue; }
-                *(PBYTE)(pb + wAddr + oAddr + 1) = (dwData >> 24) & 0xff;
-                *(PBYTE)(pb + wAddr + oAddr + 0) = (dwData >> 16) & 0xff;
-            }
-        }
-        if(raSingleDW) { break; }
-    }
-    return TRUE;
+    DEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT ReadContext = { ctx, raSingleDW };
+    if(!ctx || !pb) { return FALSE; }
+    return DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+        &ReadContext, DeviceFPGA_PCIeCfgSpaceCoreReadAttempt, pb, raSingleDW);
 }
 
 /*
@@ -1773,9 +1765,17 @@ VOID DeviceFPGA_ConfigPrint(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONTEXT_FPGA ct
 _Success_(return)
 BOOL DeviceFPGA_GetPHYv4(_In_ PDEVICE_CONTEXT_FPGA ctx)
 {
-    return
-        DeviceFPGA_ConfigRead(ctx, 0x0016, (PBYTE)&ctx->phy.wr, sizeof(ctx->phy.wr), FPGA_REG_PCIE | FPGA_REG_READWRITE) &&
-        DeviceFPGA_ConfigRead(ctx, 0x000a, (PBYTE)&ctx->phy.rd, sizeof(ctx->phy.rd), FPGA_REG_PCIE | FPGA_REG_READONLY);
+    DWORD i;
+    DEV_CFG_PHY phy;
+    for(i = 0; i < 2; i++) {
+        ZeroMemory(&phy, sizeof(phy));
+        if(DeviceFPGA_ConfigRead(ctx, 0x0016, (PBYTE)&phy.wr, sizeof(phy.wr), FPGA_REG_PCIE | FPGA_REG_READWRITE) &&
+           DeviceFPGA_ConfigRead(ctx, 0x000a, (PBYTE)&phy.rd, sizeof(phy.rd), FPGA_REG_PCIE | FPGA_REG_READONLY)) {
+            ctx->phy = phy;
+            return TRUE;
+        }
+    }
+    return FALSE;
 }
 
 _Success_(return)
@@ -1825,17 +1825,6 @@ BOOL DeviceFPGA_GetSetPHYv3(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ BOOL isUpdate)
         }
     }
     return FALSE;
-}
-
-BYTE DeviceFPGA_PHY_GetLinkWidth(_In_ PDEVICE_CONTEXT_FPGA ctx)
-{
-    const BYTE LINK_WIDTH[4] = { 1, 2, 4, 8 };
-    return LINK_WIDTH[ctx->phy.rd.pl_sel_lnk_width];
-}
-
-BYTE DeviceFPGA_PHY_GetPCIeGen(_In_ PDEVICE_CONTEXT_FPGA ctx)
-{
-    return 1 + ctx->phy.rd.pl_sel_lnk_rate;
 }
 
 VOID DeviceFPGA_SetSpeedPCIeGen(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ DWORD dwPCIeGen)
@@ -4772,7 +4761,10 @@ BOOL DeviceFPGA_Command(
             }
             if(ppbDataOut) {
                 if(!(pb = LocalAlloc(LMEM_ZEROINIT, 0x100))) { return FALSE; }
-                DeviceFPGA_ConfigRead(ctx, qwOptionLo & 0x3fff, pb, 0x100, fCfgRegConfig);
+                if(!DeviceFPGA_ConfigRead(ctx, qwOptionLo & 0x3fff, pb, 0x100, fCfgRegConfig)) {
+                    LocalFree(pb);
+                    return FALSE;
+                }
                 if(pcbDataOut) { *pcbDataOut = min(0x100, *(PDWORD)(pb + 4)); }
                 *ppbDataOut = pb;
             }
@@ -5041,8 +5033,9 @@ BOOL DeviceFPGA_Open(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO 
     LPSTR szDeviceError = NULL;
     PDEVICE_CONTEXT_FPGA ctx;
     PLC_DEVICE_PARAMETER_ENTRY pParam;
-    BOOL fFT601 = FALSE, fCustomDriver = FALSE;
+    BOOL fFT601 = FALSE, fCustomDriver = FALSE, fPCIeConfigRead = FALSE;
     BYTE pb200[0x200];
+    BYTE bPCIeGen, bPCIeWidth;
     DWORD dwVIDPID;
     if(ppLcCreateErrorInfo) { *ppLcCreateErrorInfo = NULL; }
     ctx = LocalAlloc(LMEM_ZEROINIT, sizeof(DEVICE_CONTEXT_FPGA));
@@ -5126,25 +5119,47 @@ BOOL DeviceFPGA_Open(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO 
     // return
     if(ctxLC->fPrintf[LC_PRINTF_V]) {
         *(PDWORD)pb200 = 0;
+        fPCIeConfigRead = FALSE;
         if(ctx->dev.fInitialized && ctx->wFpgaVersionMajor) {
-            DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);
+            fPCIeConfigRead = DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);
         }
         dwVIDPID = *(PDWORD)pb200;
-        lcprintfv(ctxLC,
-            "DEVICE: FPGA: %s PCIe gen%i x%i [%i,%i,%i] [v%i.%i,%04x] [%s,%s%s]\n",
-            ctx->perf.SZ_DEVICE_NAME,
-            DeviceFPGA_PHY_GetPCIeGen(ctx),
-            DeviceFPGA_PHY_GetLinkWidth(ctx),
-            ctx->perf.DELAY_READ,
-            ctx->perf.DELAY_WRITE,
-            ctx->perf.DELAY_PROBE_READ,
-            ctx->wFpgaVersionMajor,
-            ctx->wFpgaVersionMinor,
-            ctx->wDeviceId,
-            (ctx->async2.fEnabled ? "ASYNC" : (ctx->async2.fOldAsync ? "OLDASYNC" : "SYNC")),
-            (ctx->fAlgorithmReadTiny ? "TINY" : "NORM"),
-            ((!dwVIDPID || (dwVIDPID == 0x066610ee)) ? "" : ",FWCUST")
-        );
+        if(DeviceFPGA_Session_GetPCIeLinkInfo(
+            ctx->phySupported,
+            ctx->phy.rd.pl_sel_lnk_rate,
+            ctx->phy.rd.pl_sel_lnk_width,
+            &bPCIeGen,
+            &bPCIeWidth)) {
+            lcprintfv(ctxLC,
+                "DEVICE: FPGA: %s PCIe gen%i x%i [%i,%i,%i] [v%i.%i,%04x] [%s,%s%s]\n",
+                ctx->perf.SZ_DEVICE_NAME,
+                bPCIeGen,
+                bPCIeWidth,
+                ctx->perf.DELAY_READ,
+                ctx->perf.DELAY_WRITE,
+                ctx->perf.DELAY_PROBE_READ,
+                ctx->wFpgaVersionMajor,
+                ctx->wFpgaVersionMinor,
+                ctx->wDeviceId,
+                (ctx->async2.fEnabled ? "ASYNC" : (ctx->async2.fOldAsync ? "OLDASYNC" : "SYNC")),
+                (ctx->fAlgorithmReadTiny ? "TINY" : "NORM"),
+                (DeviceFPGA_Session_IsCustomPCIeConfig(fPCIeConfigRead, dwVIDPID) ? ",FWCUST" : "")
+            );
+        } else {
+            lcprintfv(ctxLC,
+                "DEVICE: FPGA: %s PCIe unknown [%i,%i,%i] [v%i.%i,%04x] [%s,%s%s]\n",
+                ctx->perf.SZ_DEVICE_NAME,
+                ctx->perf.DELAY_READ,
+                ctx->perf.DELAY_WRITE,
+                ctx->perf.DELAY_PROBE_READ,
+                ctx->wFpgaVersionMajor,
+                ctx->wFpgaVersionMinor,
+                ctx->wDeviceId,
+                (ctx->async2.fEnabled ? "ASYNC" : (ctx->async2.fOldAsync ? "OLDASYNC" : "SYNC")),
+                (ctx->fAlgorithmReadTiny ? "TINY" : "NORM"),
+                (DeviceFPGA_Session_IsCustomPCIeConfig(fPCIeConfigRead, dwVIDPID) ? ",FWCUST" : "")
+            );
+        }
     }
     if(ctxLC->fPrintf[LC_PRINTF_VV] && ctx->dev.fInitialized) {
         DeviceFPGA_ConfigPrint(ctxLC, ctx);
@@ -5156,8 +5171,9 @@ fail:
     }
     if(szDeviceError && ctxLC->fPrintf[LC_PRINTF_ENABLE]) {
         *(PDWORD)pb200 = 0;
+        fPCIeConfigRead = FALSE;
         if(ctx->dev.fInitialized && ctx->wFpgaVersionMajor) {
-            DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);
+            fPCIeConfigRead = DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);
         }
         dwVIDPID = *(PDWORD)pb200;
         lcprintf(ctxLC,
@@ -5167,7 +5183,7 @@ fail:
             ctx->wFpgaVersionMajor,
             ctx->wFpgaVersionMinor,
             ctx->wDeviceId,
-            ((!dwVIDPID || (dwVIDPID == 0x066610ee)) ? "" : ",FWCUST")
+            (DeviceFPGA_Session_IsCustomPCIeConfig(fPCIeConfigRead, dwVIDPID) ? ",FWCUST" : "")
         );
     }
     DeviceFPGA_Close(ctxLC);

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -1509,13 +1509,16 @@ static BOOL DeviceFPGA_PCIeCfgSpaceCoreReadAttempt(
     PDEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT pReadContext =
         (PDEVICE_FPGA_PCIE_CONFIG_READ_CONTEXT)pvContext;
     PDEVICE_CONTEXT_FPGA ctx;
-    BYTE pbRxTx[0x1000], pbCoverage[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
-    DWORD status, cbRxTx, cBatchDWords, raSingleDW;
+    BYTE pbRxTx[0x1000];
+    BYTE pbStaged[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    BYTE pbCoverage[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    DWORD status, cbRxTx, cBatchDWords, iBatchDWord, raSingleDW;
     WORD wDWordAddr;
     if(!pReadContext || !pReadContext->ctx || !pb) { return FALSE; }
     ctx = pReadContext->ctx;
     raSingleDW = pReadContext->raSingleDW;
     if(!DeviceFPGA_TransportIOAllowed(ctx)) { return FALSE; }
+    ZeroMemory(pbStaged, sizeof(pbStaged));
     ZeroMemory(pbCoverage, sizeof(pbCoverage));
     // A 32-DWORD reply can cross the FT601's effective 1 KiB receive
     // boundary and lose its final framed result. Keep each reply below it.
@@ -1535,24 +1538,30 @@ static BOOL DeviceFPGA_PCIeCfgSpaceCoreReadAttempt(
         status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbRxTx, cbRxTx, &cbRxTx, NULL);
         if(status) { return FALSE; }
         Sleep(10);
-        if(!DeviceFPGA_Session_ReadConfigReply(
+        iBatchDWord = raSingleDW ?
+            (raSingleDW & 0x7fffffff) : wDWordAddr;
+        if(!DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
             ctx->dev.hFTDI,
             pbRxTx,
             sizeof(pbRxTx),
             &cbRxTx,
             ctx->dev.pfnFT_ReadPipe,
+            iBatchDWord,
+            cBatchDWords,
+            pbStaged,
+            pbCoverage,
             DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
             NULL,
             NULL)) {
             return FALSE;
         }
-        if(!DeviceFPGA_Session_ParsePCIeConfigReply(
-            pbRxTx, cbRxTx, pb, pbCoverage)) {
-            return FALSE;
-        }
         if(raSingleDW) { break; }
     }
-    return DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, raSingleDW);
+    if(!DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, raSingleDW)) {
+        return FALSE;
+    }
+    memcpy(pb, pbStaged, sizeof(pbStaged));
+    return TRUE;
 }
 
 /*
@@ -1741,10 +1750,11 @@ VOID DeviceFPGA_ConfigPrint(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_CONTEXT_FPGA ct
     if(ctx->wFpgaVersionMajor < 4) { return; }
     for(i = 0; i < 4; i++) {
         if(DeviceFPGA_ConfigRead(ctx, 0x0004, (PBYTE)&cb, 2, flags[i])) {
-            lcprintf(ctxLC, "\n----- FPGA DEVICE CONFIG REGISTERS: %s    SIZE: %i BYTES -----\n", szNAME[i], cb);
             cb = min(cb, sizeof(pb));
-            DeviceFPGA_ConfigRead(ctx, 0x0000, pb, cb, flags[i]);
-            Util_PrintHexAscii(ctxLC, pb, cb, 0);
+            if(DeviceFPGA_ConfigRead(ctx, 0x0000, pb, cb, flags[i])) {
+                lcprintf(ctxLC, "\n----- FPGA DEVICE CONFIG REGISTERS: %s    SIZE: %i BYTES -----\n", szNAME[i], cb);
+                Util_PrintHexAscii(ctxLC, pb, cb, 0);
+            }
         }
     }
     if(DeviceFPGA_PCIeDrpRead(ctx, pb)) {
@@ -4746,9 +4756,14 @@ BOOL DeviceFPGA_Command(
             return TRUE;
         case LC_CMD_FPGA_PCIECFGSPACE:
             if(!ppbDataOut || (ctx->wFpgaVersionMajor < 4)) { return FALSE; }
-            if(!(*ppbDataOut = LocalAlloc(LMEM_ZEROINIT, 0x1000))) { return FALSE; }
+            if(!(pb = LocalAlloc(LMEM_ZEROINIT, 0x1000))) { return FALSE; }
+            if(!DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb, 0)) {
+                LocalFree(pb);
+                return FALSE;
+            }
+            *ppbDataOut = pb;
             if(pcbDataOut) { *pcbDataOut = 0x1000; };
-            return DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, *ppbDataOut, 0);
+            return TRUE;
         case LC_CMD_FPGA_CFGREGCFG:
         case LC_CMD_FPGA_CFGREGPCIE:
             if(ctx->wFpgaVersionMajor < 4) { return FALSE; }

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -237,11 +237,14 @@ typedef ULONG(WINAPI *PFN_FT_AbortPipe)(HANDLE ftHandle, UCHAR ucPipeID);
 typedef ULONG(WINAPI *PFN_FT_GetOverlappedResult)(HANDLE ftHandle, LPOVERLAPPED pOverlapped, PULONG pulLengthTransferred, BOOL bWait);
 typedef ULONG(WINAPI *PFN_FT_InitializeOverlapped)(HANDLE ftHandle, LPOVERLAPPED pOverlapped);
 typedef ULONG(WINAPI *PFN_FT_ReleaseOverlapped)(HANDLE ftHandle, LPOVERLAPPED pOverlapped);
+typedef ULONG(WINAPI *PFN_FT_SetPipeTimeout)(HANDLE ftHandle, UCHAR ucPipeID, ULONG ulTimeoutInMs);
+
 typedef struct tdDEVICE_CONTEXT_FPGA {
     CRITICAL_SECTION Lock;
     BOOL fTransportUsable;
     BOOL fTransportSetup;
     BOOL fTransportRecoveryInProgress;
+    BOOL fOpenPipeTimeoutFailure;
     BOOL fAdaptivePollingWait;  // disable event waits after sustained issued completion loss
     DWORD dwAdaptivePollingGeneration;
     DWORD dwTransportGeneration;
@@ -294,6 +297,7 @@ typedef struct tdDEVICE_CONTEXT_FPGA {
         PFN_FT_GetOverlappedResult pfnFT_GetOverlappedResult;
         PFN_FT_InitializeOverlapped pfnFT_InitializeOverlapped;
         PFN_FT_ReleaseOverlapped pfnFT_ReleaseOverlapped;
+        PFN_FT_SetPipeTimeout pfnFT_SetPipeTimeout;
     } dev;
     FPGA_NEWASYNC2_CONTEXT async2;
     PVOID pMRdBufferX; // NULL || PFPGA_PROBE_CALLBACK || PTLP_CALLBACK_BUF_MRd_SCATTER
@@ -970,6 +974,7 @@ ftdi_retry_old:
     ctx->dev.pfnFT_GetOverlappedResult = (PFN_FT_GetOverlappedResult)GetProcAddress(ctx->dev.hModule, "FT_GetOverlappedResult");
     ctx->dev.pfnFT_InitializeOverlapped = (PFN_FT_InitializeOverlapped)GetProcAddress(ctx->dev.hModule, "FT_InitializeOverlapped");
     ctx->dev.pfnFT_ReleaseOverlapped = (PFN_FT_ReleaseOverlapped)GetProcAddress(ctx->dev.hModule, "FT_ReleaseOverlapped");
+    ctx->dev.pfnFT_SetPipeTimeout = (PFN_FT_SetPipeTimeout)GetProcAddress(ctx->dev.hModule, "FT_SetPipeTimeout");
     pfnFT_GetChipConfiguration = (ULONG(WINAPI*)(HANDLE, PVOID))GetProcAddress(ctx->dev.hModule, "FT_GetChipConfiguration");
     pfnFT_SetChipConfiguration = (ULONG(WINAPI*)(HANDLE, PVOID))GetProcAddress(ctx->dev.hModule, "FT_SetChipConfiguration");
     pfnFT_SetSuspendTimeout = (ULONG(WINAPI*)(HANDLE, ULONG))GetProcAddress(ctx->dev.hModule, "FT_SetSuspendTimeout");
@@ -986,7 +991,7 @@ ftdi_retry_old:
             fFailFTD3XXWU = fUseFTD3XXWU;
 #endif /* _WIN32 */
             if(!szErrorReason) {
-                szErrorReason = "Unable to connect to FPGA device";
+                szErrorReason = ctx->fOpenPipeTimeoutFailure ? "Unable to configure FT601 pipe timeouts" : "Unable to connect to FPGA device";
             }
             goto fail;
         }
@@ -1247,6 +1252,7 @@ static BOOL DeviceFPGA_OpenFTDIHandle(_Inout_ PDEVICE_CONTEXT_FPGA ctx)
 {
     HANDLE hFTDI = NULL;
     DWORD status;
+    ctx->fOpenPipeTimeoutFailure = FALSE;
     if(!ctx->dev.pfnFT_Create || ctx->dev.hFTDI) { return FALSE; }
     status = ctx->dev.pfnFT_Create((PVOID)ctx->qwDeviceIndex, 0x10 /*FT_OPEN_BY_INDEX*/, &hFTDI);
     if(status || !hFTDI) {
@@ -5051,6 +5057,7 @@ BOOL DeviceFPGA_Open(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO 
     BOOL fFT601 = FALSE, fCustomDriver = FALSE, fPCIeConfigRead = FALSE;
     BYTE pb200[0x200];
     BYTE bPCIeGen, bPCIeWidth;
+    CHAR szPCIeLink[32];
     DWORD dwVIDPID;
     if(ppLcCreateErrorInfo) { *ppLcCreateErrorInfo = NULL; }
     ctx = LocalAlloc(LMEM_ZEROINIT, sizeof(DEVICE_CONTEXT_FPGA));
@@ -5145,36 +5152,25 @@ BOOL DeviceFPGA_Open(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO 
             ctx->phy.rd.pl_sel_lnk_width,
             &bPCIeGen,
             &bPCIeWidth)) {
-            lcprintfv(ctxLC,
-                "DEVICE: FPGA: %s PCIe gen%i x%i [%i,%i,%i] [v%i.%i,%04x] [%s,%s%s]\n",
-                ctx->perf.SZ_DEVICE_NAME,
-                bPCIeGen,
-                bPCIeWidth,
-                ctx->perf.DELAY_READ,
-                ctx->perf.DELAY_WRITE,
-                ctx->perf.DELAY_PROBE_READ,
-                ctx->wFpgaVersionMajor,
-                ctx->wFpgaVersionMinor,
-                ctx->wDeviceId,
-                (ctx->async2.fEnabled ? "ASYNC" : (ctx->async2.fOldAsync ? "OLDASYNC" : "SYNC")),
-                (ctx->fAlgorithmReadTiny ? "TINY" : "NORM"),
-                (DeviceFPGA_Session_IsCustomPCIeConfig(fPCIeConfigRead, dwVIDPID) ? ",FWCUST" : "")
-            );
+            _snprintf_s(szPCIeLink, _countof(szPCIeLink), _TRUNCATE,
+                "PCIe gen%i x%i", bPCIeGen, bPCIeWidth);
         } else {
-            lcprintfv(ctxLC,
-                "DEVICE: FPGA: %s PCIe unknown [%i,%i,%i] [v%i.%i,%04x] [%s,%s%s]\n",
-                ctx->perf.SZ_DEVICE_NAME,
-                ctx->perf.DELAY_READ,
-                ctx->perf.DELAY_WRITE,
-                ctx->perf.DELAY_PROBE_READ,
-                ctx->wFpgaVersionMajor,
-                ctx->wFpgaVersionMinor,
-                ctx->wDeviceId,
-                (ctx->async2.fEnabled ? "ASYNC" : (ctx->async2.fOldAsync ? "OLDASYNC" : "SYNC")),
-                (ctx->fAlgorithmReadTiny ? "TINY" : "NORM"),
-                (DeviceFPGA_Session_IsCustomPCIeConfig(fPCIeConfigRead, dwVIDPID) ? ",FWCUST" : "")
-            );
+            strcpy_s(szPCIeLink, _countof(szPCIeLink), "PCIe unknown");
         }
+        lcprintfv(ctxLC,
+            "DEVICE: FPGA: %s %s [%i,%i,%i] [v%i.%i,%04x] [%s,%s%s]\n",
+            ctx->perf.SZ_DEVICE_NAME,
+            szPCIeLink,
+            ctx->perf.DELAY_READ,
+            ctx->perf.DELAY_WRITE,
+            ctx->perf.DELAY_PROBE_READ,
+            ctx->wFpgaVersionMajor,
+            ctx->wFpgaVersionMinor,
+            ctx->wDeviceId,
+            (ctx->async2.fEnabled ? "ASYNC" : (ctx->async2.fOldAsync ? "OLDASYNC" : "SYNC")),
+            (ctx->fAlgorithmReadTiny ? "TINY" : "NORM"),
+            (DeviceFPGA_Session_IsCustomPCIeConfig(fPCIeConfigRead, dwVIDPID) ? ",FWCUST" : "")
+        );
     }
     if(ctxLC->fPrintf[LC_PRINTF_VV] && ctx->dev.fInitialized) {
         DeviceFPGA_ConfigPrint(ctxLC, ctx);

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -1529,15 +1529,9 @@ static BOOL DeviceFPGA_PCIeCfgSpaceCoreReadAttempt(
     // A 32-DWORD reply can cross the FT601's effective 1 KiB receive
     // boundary and lose its final framed result. Keep each reply below it.
     for(wDWordAddr = 0;
-        (cBatchDWords = DeviceFPGA_Session_GetPCIeConfigBatchDWords(
-            wDWordAddr, raSingleDW));
+        (cBatchDWords = DeviceFPGA_Session_GetPCIeConfigBatchDWords(wDWordAddr, raSingleDW));
         wDWordAddr = (WORD)(wDWordAddr + cBatchDWords)) {
-        if(!DeviceFPGA_Session_BuildPCIeConfigBatch(
-            pbRxTx,
-            sizeof(pbRxTx),
-            &cbRxTx,
-            wDWordAddr,
-            raSingleDW)) {
+        if(!DeviceFPGA_Session_BuildPCIeConfigBatch(pbRxTx, sizeof(pbRxTx), &cbRxTx, wDWordAddr, raSingleDW)) {
             return FALSE;
         }
         // WRITE TxData
@@ -5146,12 +5140,7 @@ BOOL DeviceFPGA_Open(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO 
             fPCIeConfigRead = DeviceFPGA_PCIeCfgSpaceCoreRead(ctx, pb200, 0x80000000 | 0);
         }
         dwVIDPID = *(PDWORD)pb200;
-        if(DeviceFPGA_Session_GetPCIeLinkInfo(
-            ctx->phySupported,
-            ctx->phy.rd.pl_sel_lnk_rate,
-            ctx->phy.rd.pl_sel_lnk_width,
-            &bPCIeGen,
-            &bPCIeWidth)) {
+        if(DeviceFPGA_Session_GetPCIeLinkInfo(ctx->phySupported, ctx->phy.rd.pl_sel_lnk_rate, ctx->phy.rd.pl_sel_lnk_width, &bPCIeGen, &bPCIeWidth)) {
             _snprintf_s(szPCIeLink, _countof(szPCIeLink), _TRUNCATE,
                 "PCIe gen%i x%i", bPCIeGen, bPCIeWidth);
         } else {

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -294,61 +294,6 @@ BOOL DeviceFPGA_Session_IsFillerOnly(
 }
 
 /*
-* A fresh FT601 session may return one already-queued idle filler burst before
-* the configuration reply. Consume that boundary without replaying the request.
-*/
-_Success_(return)
-BOOL DeviceFPGA_Session_ReadConfigReply(
-    _In_ HANDLE hFTDI,
-    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
-    _In_ DWORD cbBuffer,
-    _Out_ PDWORD pcbRead,
-    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
-    _In_ DWORD dwTimeoutMs,
-    _In_opt_ PVOID pvTimingContext,
-    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
-)
-{
-    DWORD i;
-    QWORD qwStart;
-    ULONG cbRead;
-    if(!pcbRead) { return FALSE; }
-    *pcbRead = 0;
-    if(!hFTDI || !pbBuffer || !cbBuffer || !pfnReadPipe || !dwTimeoutMs) {
-        return FALSE;
-    }
-    // A synchronous read retains the driver's in-flight timeout; this budget
-    // bounds repeated reads before and after each driver call.
-    if(!pfnTick) { pfnTick = DeviceFPGA_Session_DefaultTick; }
-    qwStart = pfnTick(pvTimingContext);
-    for(i = 0; i < 2; i++) {
-        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
-            return FALSE;
-        }
-        cbRead = 0;
-        if(pfnReadPipe(
-            hFTDI,
-            0x82,
-            pbBuffer,
-            cbBuffer,
-            &cbRead,
-            NULL) ||
-           (cbRead > cbBuffer)) {
-            return FALSE;
-        }
-        if(!cbRead) { return FALSE; }
-        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
-            return FALSE;
-        }
-        if(!DeviceFPGA_Session_IsFillerOnly(pbBuffer, cbRead)) {
-            *pcbRead = cbRead;
-            return TRUE;
-        }
-    }
-    return FALSE;
-}
-
-/*
 * Configuration replies may be preceded by framed responses from earlier
 * requests or split across receives. Accumulate a bounded sequence and return
 * only after the requested register range has complete source/address coverage.
@@ -626,7 +571,9 @@ BOOL DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
     _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
 )
 {
-    DWORD i, cbAccumulated = 0, cbReadMax;
+    BYTE pbBatchResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
+    BYTE pbBatchCoverage[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
+    DWORD i, oBatch, cbBatch, cbAccumulated = 0, cbReadMax;
     QWORD qwStart;
     ULONG cbRead;
     if(!pcbRead) { return FALSE; }
@@ -667,11 +614,15 @@ BOOL DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
         }
         cbAccumulated += cbRead;
         if(!DeviceFPGA_Session_ParsePCIeConfigReply(
-            pbBuffer, cbAccumulated, pbResult, pbCoverage)) {
+            pbBuffer, cbAccumulated, pbBatchResult, pbBatchCoverage)) {
             continue;
         }
         if(DeviceFPGA_Session_IsPCIeConfigBatchComplete(
-            pbCoverage, iDWord, cDWords)) {
+            pbBatchCoverage, iDWord, cDWords)) {
+            oBatch = iDWord * sizeof(DWORD);
+            cbBatch = cDWords * sizeof(DWORD);
+            memcpy(pbResult + oBatch, pbBatchResult + oBatch, cbBatch);
+            memcpy(pbCoverage + oBatch, pbBatchCoverage + oBatch, cbBatch);
             *pcbRead = cbAccumulated;
             return TRUE;
         }
@@ -873,6 +824,22 @@ BOOL DeviceFPGA_Session_ParseV3Identity(
     *pIdentity = Identity;
     *pwPcieDeviceId = wPcieDeviceId;
     return TRUE;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
+    _In_ HANDLE hFTDI,
+    _In_ ULONG ulTimeoutInMs,
+    _In_ PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT pfnSetPipeTimeout
+)
+{
+    ULONG ulRxStatus, ulTxStatus;
+    if(!hFTDI || !ulTimeoutInMs || !pfnSetPipeTimeout) { return FALSE; }
+    ulRxStatus = pfnSetPipeTimeout(hFTDI, 0x82, ulTimeoutInMs);
+    ulTxStatus = pfnSetPipeTimeout(hFTDI, 0x02, ulTimeoutInMs);
+    return
+        (ulRxStatus == DEVICE_FPGA_SESSION_FT_OK) &&
+        (ulTxStatus == DEVICE_FPGA_SESSION_FT_OK);
 }
 
 static QWORD DeviceFPGA_Session_DefaultTick(_In_ PVOID pvContext)

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -9,11 +9,41 @@
 #define DEVICE_FPGA_CMD_VERSION_MINOR       0x05
 #define DEVICE_FPGA_V4_IDENTITY_ATTEMPTS    5
 
+static QWORD DeviceFPGA_Session_DefaultTick(_In_ PVOID pvContext);
+
 static DWORD DeviceFPGA_Session_ReadDWORD(_In_reads_(sizeof(DWORD)) PBYTE pb)
 {
     DWORD dw;
     memcpy(&dw, pb, sizeof(dw));
     return dw;
+}
+
+BOOL DeviceFPGA_Session_GetPCIeLinkInfo(
+    _In_ BOOL fPhySupported,
+    _In_ BYTE bRate,
+    _In_ BYTE bWidthIndex,
+    _Out_opt_ PBYTE pbGen,
+    _Out_opt_ PBYTE pbWidth
+)
+{
+    const BYTE pbLinkWidth[4] = { 1, 2, 4, 8 };
+    if(pbGen) { *pbGen = 0; }
+    if(pbWidth) { *pbWidth = 0; }
+    if(!fPhySupported || !pbGen || !pbWidth || (bRate > 1) ||
+       (bWidthIndex > 3)) {
+        return FALSE;
+    }
+    *pbGen = 1 + bRate;
+    *pbWidth = pbLinkWidth[bWidthIndex];
+    return TRUE;
+}
+
+BOOL DeviceFPGA_Session_IsCustomPCIeConfig(
+    _In_ BOOL fReadSuccess,
+    _In_ DWORD dwVIDPID
+)
+{
+    return fReadSuccess && dwVIDPID && (dwVIDPID != 0x066610ee);
 }
 
 #ifndef LINUX
@@ -263,6 +293,135 @@ BOOL DeviceFPGA_Session_IsFillerOnly(
     return TRUE;
 }
 
+/*
+* A fresh FT601 session may return one already-queued idle filler burst before
+* the configuration reply. Consume that boundary without replaying the request.
+*/
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadConfigReply(
+    _In_ HANDLE hFTDI,
+    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbRead,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _In_ DWORD dwTimeoutMs,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
+)
+{
+    DWORD i;
+    QWORD qwStart;
+    ULONG cbRead;
+    if(!pcbRead) { return FALSE; }
+    *pcbRead = 0;
+    if(!hFTDI || !pbBuffer || !cbBuffer || !pfnReadPipe || !dwTimeoutMs) {
+        return FALSE;
+    }
+    // A synchronous read retains the driver's in-flight timeout; this budget
+    // bounds repeated reads before and after each driver call.
+    if(!pfnTick) { pfnTick = DeviceFPGA_Session_DefaultTick; }
+    qwStart = pfnTick(pvTimingContext);
+    for(i = 0; i < 2; i++) {
+        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
+            return FALSE;
+        }
+        cbRead = 0;
+        if(pfnReadPipe(
+            hFTDI,
+            0x82,
+            pbBuffer,
+            cbBuffer,
+            &cbRead,
+            NULL) ||
+           (cbRead > cbBuffer)) {
+            return FALSE;
+        }
+        if(!cbRead) { return FALSE; }
+        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
+            return FALSE;
+        }
+        if(!DeviceFPGA_Session_IsFillerOnly(pbBuffer, cbRead)) {
+            *pcbRead = cbRead;
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+/*
+* Configuration replies may be preceded by framed responses from earlier
+* requests or split across receives. Accumulate a bounded sequence and return
+* only after the requested register range has complete source/address coverage.
+*/
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadConfigReplyMatching(
+    _In_ HANDLE hFTDI,
+    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbRead,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cbResult) PBYTE pbResult,
+    _In_ WORD cbResult,
+    _In_ WORD flags,
+    _In_ DWORD dwTimeoutMs,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
+)
+{
+    DWORD i, cbAccumulated = 0, cbReadMax;
+    QWORD qwStart;
+    ULONG cbRead;
+    if(!pcbRead) { return FALSE; }
+    *pcbRead = 0;
+    if(!hFTDI || !pbBuffer || !cbBuffer || !pfnReadPipe ||
+       !pbResult || !cbResult || !dwTimeoutMs) {
+        return FALSE;
+    }
+    // A synchronous read retains the driver's in-flight timeout; this budget
+    // bounds repeated reads before and after each driver call.
+    if(!pfnTick) { pfnTick = DeviceFPGA_Session_DefaultTick; }
+    qwStart = pfnTick(pvTimingContext);
+    for(i = 0; i < DEVICE_FPGA_SESSION_CONFIG_REPLY_MAX_READS; i++) {
+        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
+            return FALSE;
+        }
+        if(cbAccumulated >= cbBuffer) { return FALSE; }
+        cbReadMax = cbBuffer - cbAccumulated;
+        cbRead = 0;
+        if(pfnReadPipe(
+            hFTDI,
+            0x82,
+            pbBuffer + cbAccumulated,
+            cbReadMax,
+            &cbRead,
+            NULL) ||
+           (cbRead > cbReadMax)) {
+            return FALSE;
+        }
+        if(!cbRead) { return FALSE; }
+        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
+            return FALSE;
+        }
+        if(DeviceFPGA_Session_IsFillerOnly(
+            pbBuffer + cbAccumulated, cbRead)) {
+            continue;
+        }
+        cbAccumulated += cbRead;
+        if(DeviceFPGA_Session_ParseConfigReply(
+            pbBuffer,
+            cbAccumulated,
+            wBaseAddr,
+            pbResult,
+            cbResult,
+            flags)) {
+            *pcbRead = cbAccumulated;
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 DEVICE_FPGA_SESSION_DRAIN_OUTCOME DeviceFPGA_Session_Drain(
     _Inout_ PVOID pvContext,
     _In_ PFN_DEVICE_FPGA_SESSION_DRAIN_READ pfnRead,
@@ -347,6 +506,7 @@ BOOL DeviceFPGA_Session_ParseConfigReply(
               (DeviceFPGA_Session_ReadDWORD(pbReply + i) == 0x55556666)) {
             i += sizeof(DWORD);
         }
+        if(i == cbReply) { break; }
         if(i + 32 > cbReply) { return FALSE; }
         dwStatus = DeviceFPGA_Session_ReadDWORD(pbReply + i);
         if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
@@ -376,6 +536,171 @@ BOOL DeviceFPGA_Session_ParseConfigReply(
     }
     memcpy(pbResult, pbStaged, cbResult);
     return TRUE;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ParsePCIeConfigReply(
+    _In_reads_(cbReply) PBYTE pbReply,
+    _In_ DWORD cbReply,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage
+)
+{
+    BOOL fHaveAddress = FALSE, fSawRecord = FALSE;
+    BYTE oAddress;
+    DWORD i = 0, j, dwStatus, dwData, dwAddress = 0;
+    if(!pbReply || !cbReply || !pbResult || !pbCoverage) { return FALSE; }
+    while(i < cbReply) {
+        if(i + sizeof(DWORD) > cbReply) { return FALSE; }
+        while((i + sizeof(DWORD) <= cbReply) &&
+              (DeviceFPGA_Session_ReadDWORD(pbReply + i) == 0x55556666)) {
+            i += sizeof(DWORD);
+        }
+        if(i == cbReply) { return fSawRecord; }
+        if(i + 32 > cbReply) { return FALSE; }
+        dwStatus = DeviceFPGA_Session_ReadDWORD(pbReply + i);
+        fSawRecord = TRUE;
+        if((dwStatus & 0xf0000000) == 0xe0000000) {
+            for(j = 0; j < 7; j++) {
+                dwData = DeviceFPGA_Session_ReadDWORD(
+                    pbReply + i + sizeof(DWORD) + (j * sizeof(DWORD)));
+                if((dwStatus & 0x0f) == 0x01) {
+                    if((dwData & 0x0800ffff) == 0x08002a00) {
+                        dwAddress = ((dwData >> 16) & 0x03ff) << 2;
+                        fHaveAddress = TRUE;
+                    } else if(fHaveAddress) {
+                        oAddress = (BYTE)(dwData >> 8);
+                        if(((oAddress == 0x2c) || (oAddress == 0x2e)) &&
+                           (dwAddress + (oAddress - 0x2c) + 1 <
+                            DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE)) {
+                            oAddress -= 0x2c;
+                            pbResult[dwAddress + oAddress] = (BYTE)(dwData >> 16);
+                            pbResult[dwAddress + oAddress + 1] = (BYTE)(dwData >> 24);
+                            pbCoverage[dwAddress + oAddress] = TRUE;
+                            pbCoverage[dwAddress + oAddress + 1] = TRUE;
+                        }
+                    }
+                }
+                dwStatus >>= 4;
+            }
+        }
+        i += 32;
+    }
+    return fSawRecord;
+}
+
+static BOOL DeviceFPGA_Session_IsPCIeConfigRequestValid(_In_opt_ DWORD raSingleDW)
+{
+    return !raSingleDW ||
+        ((raSingleDW & 0x80000000) &&
+         ((raSingleDW & 0x7fffffff) <
+          (DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD))));
+}
+
+DWORD DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+    _In_ DWORD iDWord,
+    _In_opt_ DWORD raSingleDW
+)
+{
+    DWORD cRemaining;
+    if(!DeviceFPGA_Session_IsPCIeConfigRequestValid(raSingleDW) ||
+       (iDWord >= DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD))) {
+        return 0;
+    }
+    if(raSingleDW) { return 1; }
+    cRemaining =
+        (DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD)) - iDWord;
+    return (cRemaining < DEVICE_FPGA_SESSION_PCIE_CONFIG_BATCH_DWORDS) ?
+        cRemaining : DEVICE_FPGA_SESSION_PCIE_CONFIG_BATCH_DWORDS;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_BuildPCIeConfigBatch(
+    _Out_writes_to_(cbBuffer, *pcbBatch) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbBatch,
+    _In_ DWORD iDWord,
+    _In_opt_ DWORD raSingleDW
+)
+{
+    BYTE pbTxLockEnable[]   = { 0x04, 0x00, 0x04, 0x00, 0x80, 0x02, 0x21, 0x77 };
+    BYTE pbTxLockDisable[]  = { 0x00, 0x00, 0x04, 0x00, 0x80, 0x02, 0x21, 0x77 };
+    BYTE pbTxReadEnable[]   = { 0x01, 0x00, 0x01, 0x00, 0x80, 0x02, 0x21, 0x77 };
+    BYTE pbTxAddress[]      = { 0x00, 0x00, 0xff, 0x03, 0x80, 0x14, 0x21, 0x77 };
+    BYTE pbTxResultMeta[]   = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a, 0x11, 0x77 };
+    BYTE pbTxResultDataLo[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x2c, 0x11, 0x77 };
+    BYTE pbTxResultDataHi[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x2e, 0x11, 0x77 };
+    DWORD cDWords, cbRequired, cbBatch = 0, i, iAddress, oDWord;
+    if(!pcbBatch) { return FALSE; }
+    *pcbBatch = 0;
+    cDWords = DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+        iDWord, raSingleDW);
+    cbRequired = cDWords * 56 + 16;
+    if(!pbBuffer || !cDWords || (cbBuffer < cbRequired)) { return FALSE; }
+    for(oDWord = 0; oDWord < cDWords; oDWord++) {
+        memcpy(pbBuffer + cbBatch, pbTxLockEnable, 8); cbBatch += 8;
+        iAddress = raSingleDW ?
+            (raSingleDW & 0x7fffffff) : (iDWord + oDWord);
+        pbTxAddress[0] = (BYTE)iAddress;
+        pbTxAddress[1] = (BYTE)((iAddress >> 8) & 0x03);
+        // The first DWORD is read twice to clear lingering result-register data.
+        for(i = 0; i < (oDWord ? 1U : 2U); i++) {
+            memcpy(pbBuffer + cbBatch, pbTxAddress, 8); cbBatch += 8;
+            memcpy(pbBuffer + cbBatch, pbTxReadEnable, 8); cbBatch += 8;
+        }
+        memcpy(pbBuffer + cbBatch, pbTxResultMeta, 8); cbBatch += 8;
+        memcpy(pbBuffer + cbBatch, pbTxResultDataLo, 8); cbBatch += 8;
+        memcpy(pbBuffer + cbBatch, pbTxResultDataHi, 8); cbBatch += 8;
+        memcpy(pbBuffer + cbBatch, pbTxLockDisable, 8); cbBatch += 8;
+    }
+    *pcbBatch = cbBatch;
+    return cbBatch == cbRequired;
+}
+
+BOOL DeviceFPGA_Session_IsPCIeConfigComplete(
+    _In_reads_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage,
+    _In_opt_ DWORD raSingleDW
+)
+{
+    DWORD i, iLimit;
+    if(!pbCoverage ||
+       !DeviceFPGA_Session_IsPCIeConfigRequestValid(raSingleDW)) {
+        return FALSE;
+    }
+    if(raSingleDW) {
+        i = raSingleDW & 0x7fffffff;
+        i *= sizeof(DWORD);
+        iLimit = i + sizeof(DWORD);
+    } else {
+        i = 0;
+        iLimit = DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE;
+    }
+    for(; i < iLimit; i++) {
+        if(!pbCoverage[i]) { return FALSE; }
+    }
+    return TRUE;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+    _Inout_ PVOID pvContext,
+    _In_ PFN_DEVICE_FPGA_SESSION_PCIE_CONFIG_READ_ATTEMPT pfnAttempt,
+    _Out_writes_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult,
+    _In_opt_ DWORD raSingleDW
+)
+{
+    DWORD i;
+    if(!pfnAttempt || !pbResult ||
+       !DeviceFPGA_Session_IsPCIeConfigRequestValid(raSingleDW)) {
+        return FALSE;
+    }
+    for(i = 0; i < 2; i++) {
+        ZeroMemory(pbResult, DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE);
+        if(pfnAttempt(pvContext, pbResult)) {
+            return TRUE;
+        }
+    }
+    return FALSE;
 }
 
 _Success_(return)
@@ -423,6 +748,7 @@ BOOL DeviceFPGA_Session_ParseV3Identity(
               (DeviceFPGA_Session_ReadDWORD(pbReply + i) == 0x55556666)) {
             i += sizeof(DWORD);
         }
+        if(i == cbReply) { break; }
         if(i + 32 > cbReply) { return FALSE; }
         dwStatus = DeviceFPGA_Session_ReadDWORD(pbReply + i);
         if((dwStatus & 0xf0000000) != 0xe0000000) { continue; }
@@ -456,22 +782,6 @@ BOOL DeviceFPGA_Session_ParseV3Identity(
     *pIdentity = Identity;
     *pwPcieDeviceId = wPcieDeviceId;
     return TRUE;
-}
-
-_Success_(return)
-BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
-    _In_ HANDLE hFTDI,
-    _In_ ULONG ulTimeoutInMs,
-    _In_ PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT pfnSetPipeTimeout
-)
-{
-    ULONG ulRxStatus, ulTxStatus;
-    if(!hFTDI || !ulTimeoutInMs || !pfnSetPipeTimeout) { return FALSE; }
-    ulRxStatus = pfnSetPipeTimeout(hFTDI, 0x82, ulTimeoutInMs);
-    ulTxStatus = pfnSetPipeTimeout(hFTDI, 0x02, ulTimeoutInMs);
-    return
-        (ulRxStatus == DEVICE_FPGA_SESSION_FT_OK) &&
-        (ulTxStatus == DEVICE_FPGA_SESSION_FT_OK);
 }
 
 static QWORD DeviceFPGA_Session_DefaultTick(_In_ PVOID pvContext)

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -589,6 +589,96 @@ BOOL DeviceFPGA_Session_ParsePCIeConfigReply(
     return fSawRecord;
 }
 
+static BOOL DeviceFPGA_Session_IsPCIeConfigBatchComplete(
+    _In_reads_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage,
+    _In_ DWORD iDWord,
+    _In_ DWORD cDWords
+)
+{
+    DWORD i, iLimit;
+    if(!pbCoverage || !cDWords ||
+       (iDWord >= DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD)) ||
+       (cDWords >
+        (DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD)) - iDWord)) {
+        return FALSE;
+    }
+    i = iDWord * sizeof(DWORD);
+    iLimit = i + (cDWords * sizeof(DWORD));
+    for(; i < iLimit; i++) {
+        if(!pbCoverage[i]) { return FALSE; }
+    }
+    return TRUE;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
+    _In_ HANDLE hFTDI,
+    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbRead,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _In_ DWORD iDWord,
+    _In_ DWORD cDWords,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage,
+    _In_ DWORD dwTimeoutMs,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
+)
+{
+    DWORD i, cbAccumulated = 0, cbReadMax;
+    QWORD qwStart;
+    ULONG cbRead;
+    if(!pcbRead) { return FALSE; }
+    *pcbRead = 0;
+    if(!hFTDI || !pbBuffer || !cbBuffer || !pfnReadPipe ||
+       !pbResult || !pbCoverage || !dwTimeoutMs || !cDWords ||
+       (iDWord >= DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD)) ||
+       (cDWords >
+        (DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE / sizeof(DWORD)) - iDWord)) {
+        return FALSE;
+    }
+    if(!pfnTick) { pfnTick = DeviceFPGA_Session_DefaultTick; }
+    qwStart = pfnTick(pvTimingContext);
+    for(i = 0; i < DEVICE_FPGA_SESSION_CONFIG_REPLY_MAX_READS; i++) {
+        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
+            return FALSE;
+        }
+        if(cbAccumulated >= cbBuffer) { return FALSE; }
+        cbReadMax = cbBuffer - cbAccumulated;
+        cbRead = 0;
+        if(pfnReadPipe(
+            hFTDI,
+            0x82,
+            pbBuffer + cbAccumulated,
+            cbReadMax,
+            &cbRead,
+            NULL) ||
+           (cbRead > cbReadMax)) {
+            return FALSE;
+        }
+        if(!cbRead) { return FALSE; }
+        if(pfnTick(pvTimingContext) - qwStart >= dwTimeoutMs) {
+            return FALSE;
+        }
+        if(DeviceFPGA_Session_IsFillerOnly(
+            pbBuffer + cbAccumulated, cbRead)) {
+            continue;
+        }
+        cbAccumulated += cbRead;
+        if(!DeviceFPGA_Session_ParsePCIeConfigReply(
+            pbBuffer, cbAccumulated, pbResult, pbCoverage)) {
+            continue;
+        }
+        if(DeviceFPGA_Session_IsPCIeConfigBatchComplete(
+            pbCoverage, iDWord, cDWords)) {
+            *pcbRead = cbAccumulated;
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 static BOOL DeviceFPGA_Session_IsPCIeConfigRequestValid(_In_opt_ DWORD raSingleDW)
 {
     return !raSingleDW ||
@@ -700,6 +790,7 @@ BOOL DeviceFPGA_Session_ReadPCIeConfigWithRetry(
             return TRUE;
         }
     }
+    ZeroMemory(pbResult, DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE);
     return FALSE;
 }
 

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -312,6 +312,22 @@ BOOL DeviceFPGA_Session_ParsePCIeConfigReply(
     _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage
 );
 
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
+    _In_ HANDLE hFTDI,
+    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbRead,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _In_ DWORD iDWord,
+    _In_ DWORD cDWords,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage,
+    _In_ DWORD dwTimeoutMs,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
+);
+
 BOOL DeviceFPGA_Session_IsPCIeConfigComplete(
     _In_reads_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage,
     _In_opt_ DWORD raSingleDW

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -142,6 +142,12 @@ typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED)(
     _In_ LPOVERLAPPED pOverlapped
 );
 
+typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT)(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _In_ ULONG ulTimeoutInMs
+);
+
 #define DEVICE_FPGA_SESSION_FT_OK                  0
 #define DEVICE_FPGA_SESSION_FT_TIMEOUT             19
 #define DEVICE_FPGA_SESSION_FT_IO_PENDING          24
@@ -251,18 +257,6 @@ BOOL DeviceFPGA_Session_IsFillerOnly(
 );
 
 _Success_(return)
-BOOL DeviceFPGA_Session_ReadConfigReply(
-    _In_ HANDLE hFTDI,
-    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
-    _In_ DWORD cbBuffer,
-    _Out_ PDWORD pcbRead,
-    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
-    _In_ DWORD dwTimeoutMs,
-    _In_opt_ PVOID pvTimingContext,
-    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
-);
-
-_Success_(return)
 BOOL DeviceFPGA_Session_ReadConfigReplyMatching(
     _In_ HANDLE hFTDI,
     _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
@@ -369,6 +363,13 @@ BOOL DeviceFPGA_Session_ParseV3Identity(
     _In_ DWORD cbReply,
     _Out_ PDEVICE_FPGA_IDENTITY pIdentity,
     _Out_ PWORD pwPcieDeviceId
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
+    _In_ HANDLE hFTDI,
+    _In_ ULONG ulTimeoutInMs,
+    _In_ PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT pfnSetPipeTimeout
 );
 
 _Success_(return)

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -19,6 +19,29 @@ typedef BOOL(*PFN_DEVICE_FPGA_SESSION_CONFIG_READ)(
     _In_ WORD flags
 );
 
+#define DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE  0x200
+#define DEVICE_FPGA_SESSION_PCIE_CONFIG_BATCH_DWORDS  16
+
+// Each attempt owns its validation state and returns TRUE only after pbResult
+// contains complete coverage for the requested read.
+typedef BOOL(*PFN_DEVICE_FPGA_SESSION_PCIE_CONFIG_READ_ATTEMPT)(
+    _Inout_ PVOID pvContext,
+    _Out_writes_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult
+);
+
+BOOL DeviceFPGA_Session_GetPCIeLinkInfo(
+    _In_ BOOL fPhySupported,
+    _In_ BYTE bRate,
+    _In_ BYTE bWidthIndex,
+    _Out_opt_ PBYTE pbGen,
+    _Out_opt_ PBYTE pbWidth
+);
+
+BOOL DeviceFPGA_Session_IsCustomPCIeConfig(
+    _In_ BOOL fReadSuccess,
+    _In_ DWORD dwVIDPID
+);
+
 typedef enum tdDEVICE_FPGA_SESSION_TLP_FRAME_ACTION {
     DEVICE_FPGA_SESSION_TLP_FRAME_IGNORE = 0,
     DEVICE_FPGA_SESSION_TLP_FRAME_APPEND,
@@ -104,6 +127,9 @@ typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_READ_PIPE)(
     _In_ LPOVERLAPPED pOverlapped
 );
 
+#define DEVICE_FPGA_SESSION_CONFIG_REPLY_MAX_READS  8
+#define DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS 5000
+
 typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT)(
     _In_ HANDLE hFTDI,
     _In_ LPOVERLAPPED pOverlapped,
@@ -114,12 +140,6 @@ typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT)(
 typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED)(
     _In_ HANDLE hFTDI,
     _In_ LPOVERLAPPED pOverlapped
-);
-
-typedef ULONG(WINAPI *PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT)(
-    _In_ HANDLE hFTDI,
-    _In_ UCHAR ucPipeID,
-    _In_ ULONG ulTimeoutInMs
 );
 
 #define DEVICE_FPGA_SESSION_FT_OK                  0
@@ -230,6 +250,34 @@ BOOL DeviceFPGA_Session_IsFillerOnly(
     _In_ DWORD cb
 );
 
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadConfigReply(
+    _In_ HANDLE hFTDI,
+    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbRead,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _In_ DWORD dwTimeoutMs,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadConfigReplyMatching(
+    _In_ HANDLE hFTDI,
+    _Out_writes_to_(cbBuffer, *pcbRead) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbRead,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _In_ WORD wBaseAddr,
+    _Out_writes_(cbResult) PBYTE pbResult,
+    _In_ WORD cbResult,
+    _In_ WORD flags,
+    _In_ DWORD dwTimeoutMs,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick
+);
+
 DEVICE_FPGA_SESSION_DRAIN_OUTCOME DeviceFPGA_Session_Drain(
     _Inout_ PVOID pvContext,
     _In_ PFN_DEVICE_FPGA_SESSION_DRAIN_READ pfnRead,
@@ -255,6 +303,43 @@ BOOL DeviceFPGA_Session_ParseConfigReply(
 );
 
 _Success_(return)
+// Accumulates into caller-owned buffers. Callers must zero both buffers before
+// parsing the first reply batch of a complete read attempt.
+BOOL DeviceFPGA_Session_ParsePCIeConfigReply(
+    _In_reads_(cbReply) PBYTE pbReply,
+    _In_ DWORD cbReply,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult,
+    _Inout_updates_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage
+);
+
+BOOL DeviceFPGA_Session_IsPCIeConfigComplete(
+    _In_reads_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbCoverage,
+    _In_opt_ DWORD raSingleDW
+);
+
+DWORD DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+    _In_ DWORD iDWord,
+    _In_opt_ DWORD raSingleDW
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_BuildPCIeConfigBatch(
+    _Out_writes_to_(cbBuffer, *pcbBatch) PBYTE pbBuffer,
+    _In_ DWORD cbBuffer,
+    _Out_ PDWORD pcbBatch,
+    _In_ DWORD iDWord,
+    _In_opt_ DWORD raSingleDW
+);
+
+_Success_(return)
+BOOL DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+    _Inout_ PVOID pvContext,
+    _In_ PFN_DEVICE_FPGA_SESSION_PCIE_CONFIG_READ_ATTEMPT pfnAttempt,
+    _Out_writes_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult,
+    _In_opt_ DWORD raSingleDW
+);
+
+_Success_(return)
 BOOL DeviceFPGA_Session_ReadV4Identity(
     _In_ PVOID pvContext,
     _In_ PFN_DEVICE_FPGA_SESSION_CONFIG_READ pfnConfigRead,
@@ -268,13 +353,6 @@ BOOL DeviceFPGA_Session_ParseV3Identity(
     _In_ DWORD cbReply,
     _Out_ PDEVICE_FPGA_IDENTITY pIdentity,
     _Out_ PWORD pwPcieDeviceId
-);
-
-_Success_(return)
-BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
-    _In_ HANDLE hFTDI,
-    _In_ ULONG ulTimeoutInMs,
-    _In_ PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT pfnSetPipeTimeout
 );
 
 _Success_(return)

--- a/leechcore/oscompatibility.h
+++ b/leechcore/oscompatibility.h
@@ -139,6 +139,7 @@ typedef int(*_CoreCrtNonSecureSearchSortCompareFunction)(void const *, void cons
 #define _Out_writes_(x)
 #define __bcount(x)
 #define _Inout_bytecount_(x)
+#define _Inout_updates_(x)
 #define _Inout_updates_opt_(x)
 #define _Inout_updates_bytes_(x)
 #define _Out_writes_opt_(x)

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -72,6 +72,24 @@ static VOID TestCompleteAlignedReply(VOID)
     ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
 }
 
+static VOID TestCompleteReplyAcceptsTrailingFiller(VOID)
+{
+    BYTE pbReply[64] = {
+        0x33, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x04, 0x13,
+        0x00, 0x0a, 0x04, 0x00
+    };
+    BYTE pbActual[3] = { 0xaa, 0xbb, 0xcc };
+    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
+    DWORD i, dwFiller = 0x55556666;
+    for(i = 32; i < sizeof(pbReply); i += sizeof(dwFiller)) {
+        memcpy(pbReply + i, &dwFiller, sizeof(dwFiller));
+    }
+    ASSERT_TRUE(DeviceFPGA_Session_ParseConfigReply(
+        pbReply, sizeof(pbReply), 0x0008, pbActual, sizeof(pbActual), 0x0003));
+    ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
 static VOID TestCompleteUnalignedReply(VOID)
 {
     BYTE pbReply[32] = {
@@ -133,6 +151,283 @@ static VOID TestWrongSourceReplyFailsAndClearsOutput(VOID)
     ASSERT_FALSE(DeviceFPGA_Session_ParseConfigReply(
         pbReply, sizeof(pbReply), 0x0008, pbActual, sizeof(pbActual), 0x0003));
     ASSERT_BYTES(pbActual, pbExpected, sizeof(pbActual));
+}
+
+static VOID BuildPCIeConfigReplyRecord(
+    _Out_writes_(32) PBYTE pbRecord,
+    _In_ DWORD dwData
+)
+{
+    DWORD dwStatus = 0xe0000001;
+    ZeroMemory(pbRecord, 32);
+    memcpy(pbRecord, &dwStatus, sizeof(dwStatus));
+    memcpy(pbRecord + sizeof(dwStatus), &dwData, sizeof(dwData));
+}
+
+static VOID TestPCIeConfigParserPlacesOneDwordAndMarksCoverage(VOID)
+{
+    BYTE pbReply[100];
+    BYTE pbResult[0x200] = { 0 };
+    BYTE pbCoverage[0x200] = { 0 };
+    DWORD dwFiller = 0x55556666;
+    memcpy(pbReply, &dwFiller, sizeof(dwFiller));
+    BuildPCIeConfigReplyRecord(pbReply + 4, 0x08042a00);
+    BuildPCIeConfigReplyRecord(pbReply + 36, 0x22112c00);
+    BuildPCIeConfigReplyRecord(pbReply + 68, 0x44332e00);
+    ASSERT_TRUE(DeviceFPGA_Session_ParsePCIeConfigReply(
+        pbReply, sizeof(pbReply), pbResult, pbCoverage));
+    ASSERT_EQ(pbResult[0x10], 0x11);
+    ASSERT_EQ(pbResult[0x11], 0x22);
+    ASSERT_EQ(pbResult[0x12], 0x33);
+    ASSERT_EQ(pbResult[0x13], 0x44);
+    ASSERT_EQ(pbCoverage[0x10], 1);
+    ASSERT_EQ(pbCoverage[0x11], 1);
+    ASSERT_EQ(pbCoverage[0x12], 1);
+    ASSERT_EQ(pbCoverage[0x13], 1);
+    ASSERT_EQ(pbCoverage[0x0f], 0);
+    ASSERT_EQ(pbCoverage[0x14], 0);
+}
+
+static VOID TestPCIeConfigParserAcceptsCompleteSpaceCoverage(VOID)
+{
+    BYTE pbReply[32 * 3 * 128];
+    BYTE pbResult[0x200] = { 0 };
+    BYTE pbCoverage[0x200] = { 0 };
+    DWORD i;
+    for(i = 0; i < 0x200; i += 4) {
+        BuildPCIeConfigReplyRecord(
+            pbReply + ((i >> 2) * 96) + 0,
+            0x08002a00 | ((i >> 2) << 16));
+        BuildPCIeConfigReplyRecord(
+            pbReply + ((i >> 2) * 96) + 32,
+            (((i + 1) & 0xff) << 24) | ((i & 0xff) << 16) | 0x2c00);
+        BuildPCIeConfigReplyRecord(
+            pbReply + ((i >> 2) * 96) + 64,
+            (((i + 3) & 0xff) << 24) | (((i + 2) & 0xff) << 16) | 0x2e00);
+    }
+    ASSERT_TRUE(DeviceFPGA_Session_ParsePCIeConfigReply(
+        pbReply, sizeof(pbReply), pbResult, pbCoverage));
+    ASSERT_TRUE(DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, 0));
+    for(i = 0; i < 0x200; i++) {
+        ASSERT_EQ(pbResult[i], i & 0xff);
+        ASSERT_EQ(pbCoverage[i], 1);
+    }
+}
+
+static VOID TestPCIeConfigCoverageRejectsOneMissingByte(VOID)
+{
+    BYTE pbCoverage[0x200];
+    memset(pbCoverage, 1, sizeof(pbCoverage));
+    pbCoverage[0x17] = 0;
+    ASSERT_FALSE(DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, 0));
+}
+
+static VOID TestPCIeConfigCoverageAcceptsRequestedSingleDword(VOID)
+{
+    BYTE pbCoverage[0x200] = { 0 };
+    memset(pbCoverage + 0x1fc, 1, sizeof(DWORD));
+    ASSERT_TRUE(DeviceFPGA_Session_IsPCIeConfigComplete(
+        pbCoverage, 0x80000000 | 0x7f));
+}
+
+static VOID TestPCIeConfigCoverageRejectsIncompleteSingleDword(VOID)
+{
+    BYTE pbCoverage[0x200] = { 0 };
+    memset(pbCoverage + 0x40, 1, sizeof(DWORD));
+    pbCoverage[0x42] = 0;
+    ASSERT_FALSE(DeviceFPGA_Session_IsPCIeConfigComplete(
+        pbCoverage, 0x80000000 | 0x10));
+}
+
+static VOID TestPCIeConfigCoverageRejectsOutOfRangeSingleDword(VOID)
+{
+    BYTE pbCoverage[0x200];
+    memset(pbCoverage, 1, sizeof(pbCoverage));
+    ASSERT_FALSE(DeviceFPGA_Session_IsPCIeConfigComplete(
+        pbCoverage, 0x80000000 | 0x80));
+}
+
+static VOID TestPCIeConfigParserRejectsTruncatedAndFillerOnlyReply(VOID)
+{
+    BYTE pbFillerOnly[4] = { 0x66, 0x66, 0x55, 0x55 };
+    BYTE pbTruncated[31] = { 0 };
+    BYTE pbResult[0x200] = { 0 };
+    BYTE pbCoverage[0x200] = { 0 };
+    ASSERT_FALSE(DeviceFPGA_Session_ParsePCIeConfigReply(
+        pbFillerOnly, sizeof(pbFillerOnly), pbResult, pbCoverage));
+    ASSERT_FALSE(DeviceFPGA_Session_ParsePCIeConfigReply(
+        pbTruncated, sizeof(pbTruncated), pbResult, pbCoverage));
+}
+
+static VOID TestPCIeConfigParserDoesNotCoverDataBeforeMetadata(VOID)
+{
+    BYTE pbReply[32];
+    BYTE pbResult[0x200] = { 0 };
+    BYTE pbCoverage[0x200] = { 0 };
+    BuildPCIeConfigReplyRecord(pbReply, 0x22112c00);
+    ASSERT_TRUE(DeviceFPGA_Session_ParsePCIeConfigReply(
+        pbReply, sizeof(pbReply), pbResult, pbCoverage));
+    ASSERT_EQ(pbResult[0], 0);
+    ASSERT_EQ(pbCoverage[0], 0);
+    ASSERT_FALSE(DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, 0));
+}
+
+static VOID TestPCIeConfigBatchSizingBoundsRepliesBelowTransportBoundary(VOID)
+{
+    ASSERT_EQ(DeviceFPGA_Session_GetPCIeConfigBatchDWords(0, 0), 16);
+    ASSERT_EQ(DeviceFPGA_Session_GetPCIeConfigBatchDWords(112, 0), 16);
+    ASSERT_EQ(DeviceFPGA_Session_GetPCIeConfigBatchDWords(127, 0), 1);
+    ASSERT_EQ(DeviceFPGA_Session_GetPCIeConfigBatchDWords(128, 0), 0);
+    ASSERT_EQ(DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+        0, 0x80000000 | 0x7f), 1);
+    ASSERT_EQ(DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+        0, 0x80000000 | 0x80), 0);
+}
+
+static VOID AssertPCIeConfigBatchAddresses(
+    _In_reads_(cbBatch) PBYTE pbBatch,
+    _In_ DWORD cbBatch,
+    _In_ DWORD iStartDWord,
+    _In_ DWORD cDWords
+)
+{
+    DWORD i, iAddress = 0, iExpected;
+    for(i = 0; i + 8 <= cbBatch; i += 8) {
+        if((pbBatch[i + 4] != 0x80) ||
+           (pbBatch[i + 5] != 0x14) ||
+           (pbBatch[i + 6] != 0x21) ||
+           (pbBatch[i + 7] != 0x77)) {
+            continue;
+        }
+        iExpected = iStartDWord + (iAddress ? iAddress - 1 : 0);
+        ASSERT_EQ(pbBatch[i], iExpected & 0xff);
+        ASSERT_EQ(pbBatch[i + 1], (iExpected >> 8) & 0x03);
+        iAddress++;
+    }
+    ASSERT_EQ(iAddress, cDWords + 1);
+}
+
+static VOID TestPCIeConfigBatchBuilderKeepsRealRequestsBelowBoundary(VOID)
+{
+    BYTE pbBatch[0x1000];
+    DWORD cbBatch, cBatchDWords, cBatches = 0, iDWord = 0;
+    while((cBatchDWords = DeviceFPGA_Session_GetPCIeConfigBatchDWords(
+        iDWord, 0))) {
+        memset(pbBatch, 0xcc, sizeof(pbBatch));
+        cbBatch = 0;
+        ASSERT_TRUE(DeviceFPGA_Session_BuildPCIeConfigBatch(
+            pbBatch, sizeof(pbBatch), &cbBatch, iDWord, 0));
+        ASSERT_EQ(cBatchDWords, 16);
+        ASSERT_EQ(cbBatch, 912);
+        ASSERT_TRUE(cbBatch < 1024);
+        ASSERT_TRUE(20 + (cBatchDWords * 32) < 1024);
+        AssertPCIeConfigBatchAddresses(
+            pbBatch, cbBatch, iDWord, cBatchDWords);
+        iDWord += cBatchDWords;
+        cBatches++;
+    }
+    ASSERT_EQ(iDWord, 128);
+    ASSERT_EQ(cBatches, 8);
+}
+
+static VOID TestPCIeConfigBatchBuilderPreservesSingleDwordRequest(VOID)
+{
+    BYTE pbBatch[0x1000];
+    DWORD cbBatch = 0;
+    ASSERT_TRUE(DeviceFPGA_Session_BuildPCIeConfigBatch(
+        pbBatch,
+        sizeof(pbBatch),
+        &cbBatch,
+        0,
+        0x80000000 | 0x7f));
+    ASSERT_EQ(cbBatch, 72);
+    AssertPCIeConfigBatchAddresses(pbBatch, cbBatch, 0x7f, 1);
+    cbBatch = 0xaa;
+    ASSERT_FALSE(DeviceFPGA_Session_BuildPCIeConfigBatch(
+        pbBatch, 71, &cbBatch, 0, 0x80000000 | 0x7f));
+    ASSERT_EQ(cbBatch, 0);
+    ASSERT_FALSE(DeviceFPGA_Session_BuildPCIeConfigBatch(
+        pbBatch,
+        sizeof(pbBatch),
+        &cbBatch,
+        0,
+        0x80000000 | 0x80));
+    ASSERT_EQ(cbBatch, 0);
+}
+
+typedef struct tdPCIE_CONFIG_READ_SCRIPT {
+    BOOL afSuccess[2];
+    BYTE abWrite[2];
+    DWORD cCalls;
+    BOOL fSecondOutputWasCleared;
+} PCIE_CONFIG_READ_SCRIPT, *PPCIE_CONFIG_READ_SCRIPT;
+
+static BOOL ScriptedPCIeConfigReadAttempt(
+    _Inout_ PVOID pvContext,
+    _Out_writes_(DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE) PBYTE pbResult
+)
+{
+    PPCIE_CONFIG_READ_SCRIPT pScript = (PPCIE_CONFIG_READ_SCRIPT)pvContext;
+    DWORD i, iAttempt = pScript->cCalls++;
+    if(iAttempt >= 2) { return FALSE; }
+    if(iAttempt == 1) {
+        for(i = 0; i < DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE; i++) {
+            if(pbResult[i]) {
+                pScript->fSecondOutputWasCleared = FALSE;
+                break;
+            }
+        }
+    }
+    memset(pbResult, pScript->abWrite[iAttempt],
+        DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE);
+    return pScript->afSuccess[iAttempt];
+}
+
+static VOID TestPCIeConfigRetryReturnsFirstAttemptSuccess(VOID)
+{
+    PCIE_CONFIG_READ_SCRIPT Script = { { TRUE, FALSE }, { 0x11, 0x00 }, 0, TRUE };
+    BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    memset(pbResult, 0xaa, sizeof(pbResult));
+    ASSERT_TRUE(DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+        &Script, ScriptedPCIeConfigReadAttempt, pbResult, 0));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(pbResult[0], 0x11);
+}
+
+static VOID TestPCIeConfigRetryClearsOutputBeforeSecondAttempt(VOID)
+{
+    PCIE_CONFIG_READ_SCRIPT Script = { { FALSE, TRUE }, { 0xaa, 0x22 }, 0, TRUE };
+    BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    memset(pbResult, 0xff, sizeof(pbResult));
+    ASSERT_TRUE(DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+        &Script, ScriptedPCIeConfigReadAttempt, pbResult, 0));
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_TRUE(Script.fSecondOutputWasCleared);
+    ASSERT_EQ(pbResult[0], 0x22);
+}
+
+static VOID TestPCIeConfigRetryStopsAfterTwoFailures(VOID)
+{
+    PCIE_CONFIG_READ_SCRIPT Script = { { FALSE, FALSE }, { 0xaa, 0x22 }, 0, TRUE };
+    BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    memset(pbResult, 0xff, sizeof(pbResult));
+    ASSERT_FALSE(DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+        &Script, ScriptedPCIeConfigReadAttempt, pbResult, 0));
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_TRUE(Script.fSecondOutputWasCleared);
+}
+
+static VOID TestPCIeConfigRetryRejectsOutOfRangeRequestWithoutAttempt(VOID)
+{
+    PCIE_CONFIG_READ_SCRIPT Script = { { TRUE, TRUE }, { 0x11, 0x22 }, 0, TRUE };
+    BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    memset(pbResult, 0xff, sizeof(pbResult));
+    ASSERT_FALSE(DeviceFPGA_Session_ReadPCIeConfigWithRetry(
+        &Script,
+        ScriptedPCIeConfigReadAttempt,
+        pbResult,
+        0x80000000 | 0x80));
+    ASSERT_EQ(Script.cCalls, 0);
 }
 
 typedef struct tdCONFIG_READ_SCRIPT {
@@ -259,6 +554,26 @@ static VOID TestV3IdentityPublishesCompleteReply(VOID)
     };
     DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
     WORD wPcieDeviceId = 0xdddd;
+    ASSERT_TRUE(DeviceFPGA_Session_ParseV3Identity(
+        pbReply, sizeof(pbReply), &Identity, &wPcieDeviceId));
+    ASSERT_IDENTITY(Identity, 4, 19, 4);
+    ASSERT_EQ(wPcieDeviceId, 0);
+}
+
+static VOID TestV3IdentityAcceptsTrailingFiller(VOID)
+{
+    BYTE pbReply[64] = {
+        0x33, 0x03, 0x00, 0xe0,
+        0x04, 0x00, 0x00, 0x01,
+        0x13, 0x00, 0x00, 0x05,
+        0x04, 0x00, 0x00, 0x03
+    };
+    DEVICE_FPGA_IDENTITY Identity = { 0xaa, 0xbb, 0xcc };
+    WORD wPcieDeviceId = 0xdddd;
+    DWORD i, dwFiller = 0x55556666;
+    for(i = 32; i < sizeof(pbReply); i += sizeof(dwFiller)) {
+        memcpy(pbReply + i, &dwFiller, sizeof(dwFiller));
+    }
     ASSERT_TRUE(DeviceFPGA_Session_ParseV3Identity(
         pbReply, sizeof(pbReply), &Identity, &wPcieDeviceId));
     ASSERT_IDENTITY(Identity, 4, 19, 4);
@@ -1078,59 +1393,6 @@ static VOID TestCloseReportsAbortErrorAfterAttemptingCleanup(VOID)
     ASSERT_EQ(Script.cReleaseCalls, 1);
 }
 
-typedef struct tdPIPE_TIMEOUT_SCRIPT {
-    BYTE pbPipe[2];
-    ULONG pulTimeout[2];
-    DWORD cCalls;
-    ULONG ulRxStatus;
-    ULONG ulTxStatus;
-} PIPE_TIMEOUT_SCRIPT, *PPIPE_TIMEOUT_SCRIPT;
-
-static ULONG WINAPI ScriptedSetPipeTimeout(
-    _In_ HANDLE hFTDI,
-    _In_ UCHAR ucPipeID,
-    _In_ ULONG ulTimeoutInMs
-)
-{
-    PPIPE_TIMEOUT_SCRIPT pScript = (PPIPE_TIMEOUT_SCRIPT)hFTDI;
-    DWORD i = pScript->cCalls++;
-    if(i < 2) {
-        pScript->pbPipe[i] = ucPipeID;
-        pScript->pulTimeout[i] = ulTimeoutInMs;
-    }
-    return (ucPipeID == 0x82) ? pScript->ulRxStatus : pScript->ulTxStatus;
-}
-
-static VOID TestConfigurePipeTimeoutsConfiguresBothDirections(VOID)
-{
-    PIPE_TIMEOUT_SCRIPT Script = { 0 };
-    ASSERT_TRUE(DeviceFPGA_Session_ConfigurePipeTimeouts(
-        &Script,
-        DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS,
-        ScriptedSetPipeTimeout));
-    ASSERT_EQ(Script.cCalls, 2);
-    ASSERT_EQ(Script.pbPipe[0], 0x82);
-    ASSERT_EQ(Script.pbPipe[1], 0x02);
-    ASSERT_EQ(Script.pulTimeout[0], DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS);
-    ASSERT_EQ(Script.pulTimeout[1], DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS);
-}
-
-static VOID TestConfigurePipeTimeoutsReportsEitherFailure(VOID)
-{
-    PIPE_TIMEOUT_SCRIPT RxFailure = { { 0 }, { 0 }, 0, 1, 0 };
-    PIPE_TIMEOUT_SCRIPT TxFailure = { { 0 }, { 0 }, 0, 0, 1 };
-    ASSERT_FALSE(DeviceFPGA_Session_ConfigurePipeTimeouts(
-        &RxFailure,
-        DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS,
-        ScriptedSetPipeTimeout));
-    ASSERT_EQ(RxFailure.cCalls, 2);
-    ASSERT_FALSE(DeviceFPGA_Session_ConfigurePipeTimeouts(
-        &TxFailure,
-        DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS,
-        ScriptedSetPipeTimeout));
-    ASSERT_EQ(TxFailure.cCalls, 2);
-}
-
 #define RECOVERY_EVENT_QUIESCE      1
 #define RECOVERY_EVENT_REOPEN       2
 #define RECOVERY_EVENT_INITIALIZE   3
@@ -1276,6 +1538,446 @@ static VOID TestFillerClassificationRequiresCompleteFillerWords(VOID)
         pbFramed, sizeof(pbFramed)));
     ASSERT_FALSE(DeviceFPGA_Session_IsFillerOnly(
         pbTruncated, sizeof(pbTruncated)));
+}
+
+typedef struct tdCONFIG_REPLY_READ_SCRIPT {
+    BYTE pbReply[2][32];
+    DWORD pcbReply[2];
+    DWORD cCalls;
+    DWORD dwReadDelayMs;
+    DWORD iFailureCall;
+    DWORD iOversizeCall;
+    QWORD qwNow;
+    UCHAR ucLastPipe;
+    DWORD cbLastBuffer;
+    BOOL fSawOverlapped;
+} CONFIG_REPLY_READ_SCRIPT, *PCONFIG_REPLY_READ_SCRIPT;
+
+static ULONG WINAPI ScriptedConfigReplyRead(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _Out_writes_(cbBuffer) PUCHAR pbBuffer,
+    _In_ ULONG cbBuffer,
+    _Out_ PULONG pcbTransferred,
+    _In_ LPOVERLAPPED pOverlapped
+)
+{
+    PCONFIG_REPLY_READ_SCRIPT pScript =
+        (PCONFIG_REPLY_READ_SCRIPT)hFTDI;
+    DWORD iCall = pScript->cCalls++;
+    pScript->ucLastPipe = ucPipeID;
+    pScript->cbLastBuffer = cbBuffer;
+    pScript->fSawOverlapped |= pOverlapped != NULL;
+    pScript->qwNow += pScript->dwReadDelayMs;
+    if(iCall + 1 == pScript->iFailureCall) {
+        *pcbTransferred = 0;
+        return 1;
+    }
+    if(iCall + 1 == pScript->iOversizeCall) {
+        *pcbTransferred = cbBuffer + 1;
+        return 0;
+    }
+    if(iCall >= 2 || pScript->pcbReply[iCall] > cbBuffer) {
+        *pcbTransferred = 0;
+        return 1;
+    }
+    memcpy(pbBuffer, pScript->pbReply[iCall], pScript->pcbReply[iCall]);
+    *pcbTransferred = pScript->pcbReply[iCall];
+    return 0;
+}
+
+static QWORD ScriptedConfigReplyTick(_In_opt_ PVOID pvContext)
+{
+    return ((PCONFIG_REPLY_READ_SCRIPT)pvContext)->qwNow;
+}
+
+static VOID SetConfigReplyFiller(
+    _Out_writes_(20) PBYTE pb,
+    _Out_ PDWORD pcb
+)
+{
+    DWORD i;
+    DWORD dwFiller = 0x55556666;
+    for(i = 0; i < 20; i += sizeof(dwFiller)) {
+        memcpy(pb + i, &dwFiller, sizeof(dwFiller));
+    }
+    *pcb = 20;
+}
+
+static VOID SetConfigReplyRecord(
+    _Out_writes_(32) PBYTE pb,
+    _Out_ PDWORD pcb
+)
+{
+    static const BYTE pbRecord[32] = {
+        0x33, 0x00, 0x00, 0xe0,
+        0x00, 0x08, 0x04, 0x13,
+        0x00, 0x0a, 0x04, 0x00
+    };
+    memcpy(pb, pbRecord, sizeof(pbRecord));
+    *pcb = sizeof(pbRecord);
+}
+
+static VOID TestConfigReplyReadSkipsOneFillerOnlyReceive(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
+    DWORD cbRead = 0;
+    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
+    SetConfigReplyRecord(Script.pbReply[1], &Script.pcbReply[1]);
+    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReply(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_EQ(Script.ucLastPipe, 0x82);
+    ASSERT_EQ(Script.cbLastBuffer, sizeof(pbBuffer));
+    ASSERT_FALSE(Script.fSawOverlapped);
+    ASSERT_EQ(cbRead, Script.pcbReply[1]);
+    ASSERT_BYTES(pbBuffer, Script.pbReply[1], cbRead);
+    ASSERT_TRUE(DeviceFPGA_Session_ParseConfigReply(
+        pbBuffer,
+        cbRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003));
+    ASSERT_BYTES(pbResult, pbExpected, sizeof(pbResult));
+}
+
+static VOID TestConfigReplyReadReturnsNonFillerImmediately(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    DWORD cbRead = 0;
+    SetConfigReplyRecord(Script.pbReply[0], &Script.pcbReply[0]);
+    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReply(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(cbRead, Script.pcbReply[0]);
+    ASSERT_BYTES(pbBuffer, Script.pbReply[0], cbRead);
+}
+
+static VOID TestConfigReplyReadRejectsZeroTransferImmediately(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    DWORD cbRead = 0xaa;
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(cbRead, 0);
+}
+
+static VOID TestConfigReplyReadStopsAtOverallDeadline(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    DWORD cbRead = 0xaa;
+    Script.dwReadDelayMs = 100;
+    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
+    SetConfigReplyRecord(Script.pbReply[1], &Script.pcbReply[1]);
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        100,
+        &Script,
+        ScriptedConfigReplyTick));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(cbRead, 0);
+}
+
+static VOID TestConfigReplyReadStopsAfterSecondFiller(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    DWORD cbRead = 0xaa;
+    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
+    SetConfigReplyFiller(Script.pbReply[1], &Script.pcbReply[1]);
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_EQ(cbRead, 0);
+}
+
+static VOID TestConfigReplyReadRejectsReadErrorsAndOversize(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Failure = { 0 };
+    CONFIG_REPLY_READ_SCRIPT Oversize = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    DWORD cbRead = 0xaa;
+    Failure.iFailureCall = 1;
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
+        &Failure,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Failure.cCalls, 1);
+    ASSERT_EQ(cbRead, 0);
+    Oversize.iOversizeCall = 1;
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
+        &Oversize,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Oversize.cCalls, 1);
+    ASSERT_EQ(cbRead, 0);
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
+        NULL,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(cbRead, 0);
+}
+
+typedef struct tdMATCHING_CONFIG_REPLY_SCRIPT {
+    DWORD cCalls;
+    DWORD cWrongReplies;
+    BOOL fNeverMatch;
+    BOOL fSplitReply;
+    BOOL fTrailingFiller;
+} MATCHING_CONFIG_REPLY_SCRIPT, *PMATCHING_CONFIG_REPLY_SCRIPT;
+
+static ULONG WINAPI ScriptedMatchingConfigReplyRead(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _Out_writes_(cbBuffer) PUCHAR pbBuffer,
+    _In_ ULONG cbBuffer,
+    _Out_ PULONG pcbTransferred,
+    _In_ LPOVERLAPPED pOverlapped
+)
+{
+    PMATCHING_CONFIG_REPLY_SCRIPT pScript =
+        (PMATCHING_CONFIG_REPLY_SCRIPT)hFTDI;
+    BYTE pbReply[64];
+    DWORD cbReply, i, dwFiller = 0x55556666;
+    UNREFERENCED_PARAMETER(ucPipeID);
+    UNREFERENCED_PARAMETER(pOverlapped);
+    SetConfigReplyRecord(pbReply, &cbReply);
+    if(pScript->fSplitReply) {
+        if((pScript->cCalls >= 2) || (cbBuffer < 16)) {
+            *pcbTransferred = 0;
+            return 1;
+        }
+        memcpy(pbBuffer, pbReply + (pScript->cCalls * 16), 16);
+        pScript->cCalls++;
+        *pcbTransferred = 16;
+        return 0;
+    }
+    if(pScript->fTrailingFiller) {
+        for(i = cbReply; i < sizeof(pbReply); i += sizeof(dwFiller)) {
+            memcpy(pbReply + i, &dwFiller, sizeof(dwFiller));
+        }
+        cbReply = sizeof(pbReply);
+    }
+    if(cbBuffer < cbReply) {
+        *pcbTransferred = 0;
+        return 1;
+    }
+    if(pScript->fNeverMatch ||
+       (pScript->cCalls < pScript->cWrongReplies)) {
+        pbReply[5] = 0x20;
+        pbReply[9] = 0x22;
+    }
+    memcpy(pbBuffer, pbReply, cbReply);
+    pScript->cCalls++;
+    *pcbTransferred = cbReply;
+    return 0;
+}
+
+static VOID TestConfigReplyReadSkipsUnrelatedNonFillerReplies(VOID)
+{
+    MATCHING_CONFIG_REPLY_SCRIPT Script = { 0 };
+    BYTE pbBuffer[128] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
+    DWORD cbRead = 0;
+    Script.cWrongReplies = 2;
+    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReplyMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedMatchingConfigReplyRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 3);
+    ASSERT_EQ(cbRead, 96);
+    ASSERT_BYTES(pbResult, pbExpected, sizeof(pbExpected));
+}
+
+static VOID TestConfigReplyReadBoundsUnrelatedNonFillerReplies(VOID)
+{
+    MATCHING_CONFIG_REPLY_SCRIPT Script = { 0 };
+    BYTE pbBuffer[
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_MAX_READS * 32] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    DWORD cbRead = 0xaa;
+    Script.fNeverMatch = TRUE;
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReplyMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedMatchingConfigReplyRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, DEVICE_FPGA_SESSION_CONFIG_REPLY_MAX_READS);
+    ASSERT_EQ(cbRead, 0);
+}
+
+static VOID TestMatchingConfigReplyReadRejectsZeroTransferImmediately(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    DWORD cbRead = 0xaa;
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReplyMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(cbRead, 0);
+}
+
+static VOID TestMatchingConfigReplyReadStopsAtOverallDeadline(VOID)
+{
+    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    DWORD cbRead = 0xaa;
+    Script.dwReadDelayMs = 100;
+    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
+    SetConfigReplyRecord(Script.pbReply[1], &Script.pcbReply[1]);
+    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReplyMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedConfigReplyRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003,
+        100,
+        &Script,
+        ScriptedConfigReplyTick));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(cbRead, 0);
+}
+
+static VOID TestConfigReplyReadAccumulatesSplitReply(VOID)
+{
+    MATCHING_CONFIG_REPLY_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
+    DWORD cbRead = 0;
+    Script.fSplitReply = TRUE;
+    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReplyMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedMatchingConfigReplyRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_EQ(cbRead, 32);
+    ASSERT_BYTES(pbResult, pbExpected, sizeof(pbExpected));
+}
+
+static VOID TestConfigReplyReadAcceptsTrailingFillerWithoutAnotherRead(VOID)
+{
+    MATCHING_CONFIG_REPLY_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    BYTE pbResult[3] = { 0 };
+    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
+    DWORD cbRead = 0;
+    Script.fTrailingFiller = TRUE;
+    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReplyMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedMatchingConfigReplyRead,
+        0x0008,
+        pbResult,
+        sizeof(pbResult),
+        0x0003,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(Script.cCalls, 1);
+    ASSERT_EQ(cbRead, sizeof(pbBuffer));
+    ASSERT_BYTES(pbResult, pbExpected, sizeof(pbExpected));
 }
 
 typedef struct tdDRAIN_SCRIPT {
@@ -1521,20 +2223,100 @@ static VOID TestDrainRejectsInvalidPolicy(VOID)
     ASSERT_EQ(Script.cCalls, 0);
 }
 
+static VOID AssertPCIeLinkInfo(
+    _In_ BOOL fPhySupported,
+    _In_ BYTE bRate,
+    _In_ BYTE bWidthIndex,
+    _In_ BOOL fExpected,
+    _In_ BYTE bExpectedGen,
+    _In_ BYTE bExpectedWidth
+)
+{
+    BYTE bGen = 0xaa;
+    BYTE bWidth = 0xbb;
+    ASSERT_EQ(
+        DeviceFPGA_Session_GetPCIeLinkInfo(
+            fPhySupported,
+            bRate,
+            bWidthIndex,
+            &bGen,
+            &bWidth),
+        fExpected);
+    ASSERT_EQ(bGen, bExpectedGen);
+    ASSERT_EQ(bWidth, bExpectedWidth);
+}
+
+static VOID TestPCIeLinkInfoRejectsUnavailableAndOutOfRangeState(VOID)
+{
+    BYTE bGen = 0xaa;
+    BYTE bWidth = 0xbb;
+    AssertPCIeLinkInfo(FALSE, 0, 0, FALSE, 0, 0);
+    AssertPCIeLinkInfo(TRUE, 2, 0, FALSE, 0, 0);
+    AssertPCIeLinkInfo(TRUE, 0, 4, FALSE, 0, 0);
+    ASSERT_FALSE(DeviceFPGA_Session_GetPCIeLinkInfo(
+        TRUE, 0, 0, NULL, &bWidth));
+    ASSERT_EQ(bWidth, 0);
+    ASSERT_FALSE(DeviceFPGA_Session_GetPCIeLinkInfo(
+        TRUE, 0, 0, &bGen, NULL));
+    ASSERT_EQ(bGen, 0);
+    ASSERT_FALSE(DeviceFPGA_Session_GetPCIeLinkInfo(
+        TRUE, 0, 0, NULL, NULL));
+}
+
+static VOID TestPCIeLinkInfoMapsSupportedRateAndWidthIndexes(VOID)
+{
+    AssertPCIeLinkInfo(TRUE, 0, 0, TRUE, 1, 1);
+    AssertPCIeLinkInfo(TRUE, 0, 1, TRUE, 1, 2);
+    AssertPCIeLinkInfo(TRUE, 0, 2, TRUE, 1, 4);
+    AssertPCIeLinkInfo(TRUE, 0, 3, TRUE, 1, 8);
+    AssertPCIeLinkInfo(TRUE, 1, 0, TRUE, 2, 1);
+    AssertPCIeLinkInfo(TRUE, 1, 1, TRUE, 2, 2);
+    AssertPCIeLinkInfo(TRUE, 1, 2, TRUE, 2, 4);
+    AssertPCIeLinkInfo(TRUE, 1, 3, TRUE, 2, 8);
+}
+
+static VOID TestCustomPCIeConfigRequiresSuccessfulNonDefaultRead(VOID)
+{
+    ASSERT_FALSE(DeviceFPGA_Session_IsCustomPCIeConfig(
+        FALSE, 0x12345678));
+    ASSERT_FALSE(DeviceFPGA_Session_IsCustomPCIeConfig(TRUE, 0));
+    ASSERT_FALSE(DeviceFPGA_Session_IsCustomPCIeConfig(
+        TRUE, 0x066610ee));
+    ASSERT_TRUE(DeviceFPGA_Session_IsCustomPCIeConfig(
+        TRUE, 0x12345678));
+}
+
 int main(void)
 {
     RUN_TEST(TestCompleteAlignedReply);
+    RUN_TEST(TestCompleteReplyAcceptsTrailingFiller);
     RUN_TEST(TestCompleteUnalignedReply);
     RUN_TEST(TestCompleteZeroValuedReply);
     RUN_TEST(TestEmptyReplyFailsAndClearsOutput);
     RUN_TEST(TestPartialReplyFailsAndClearsOutput);
     RUN_TEST(TestWrongSourceReplyFailsAndClearsOutput);
+    RUN_TEST(TestPCIeConfigParserPlacesOneDwordAndMarksCoverage);
+    RUN_TEST(TestPCIeConfigParserAcceptsCompleteSpaceCoverage);
+    RUN_TEST(TestPCIeConfigCoverageRejectsOneMissingByte);
+    RUN_TEST(TestPCIeConfigCoverageAcceptsRequestedSingleDword);
+    RUN_TEST(TestPCIeConfigCoverageRejectsIncompleteSingleDword);
+    RUN_TEST(TestPCIeConfigCoverageRejectsOutOfRangeSingleDword);
+    RUN_TEST(TestPCIeConfigParserRejectsTruncatedAndFillerOnlyReply);
+    RUN_TEST(TestPCIeConfigParserDoesNotCoverDataBeforeMetadata);
+    RUN_TEST(TestPCIeConfigBatchSizingBoundsRepliesBelowTransportBoundary);
+    RUN_TEST(TestPCIeConfigBatchBuilderKeepsRealRequestsBelowBoundary);
+    RUN_TEST(TestPCIeConfigBatchBuilderPreservesSingleDwordRequest);
+    RUN_TEST(TestPCIeConfigRetryReturnsFirstAttemptSuccess);
+    RUN_TEST(TestPCIeConfigRetryClearsOutputBeforeSecondAttempt);
+    RUN_TEST(TestPCIeConfigRetryStopsAfterTwoFailures);
+    RUN_TEST(TestPCIeConfigRetryRejectsOutOfRangeRequestWithoutAttempt);
     RUN_TEST(TestV4IdentityRetriesAndPublishesCompleteReply);
     RUN_TEST(TestV4IdentityFailureIsBoundedAndDoesNotPublish);
     RUN_TEST(TestV4IdentityAcceptsExplicitZeroFpgaId);
     RUN_TEST(TestV4IdentityRejectsLegacyMajorWithoutPublishing);
     RUN_TEST(TestV3IdentityRequiresEveryIdentityCommand);
     RUN_TEST(TestV3IdentityPublishesCompleteReply);
+    RUN_TEST(TestV3IdentityAcceptsTrailingFiller);
     RUN_TEST(TestV3IdentityAcceptsExplicitZeroFpgaId);
     RUN_TEST(TestTlpFrameIgnoresContinuationUntilFirst);
     RUN_TEST(TestTlpFrameCompletesAfterExplicitFirst);
@@ -1556,12 +2338,22 @@ int main(void)
     RUN_TEST(TestCloseCancelsReadPipeBeforeWaiting);
     RUN_TEST(TestClosePendingForeverIsBoundedAndStillReleases);
     RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
-    RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);
-    RUN_TEST(TestConfigurePipeTimeoutsReportsEitherFailure);
     RUN_TEST(TestRecoveryCoordinatorExecutesOneOrderedAttempt);
     RUN_TEST(TestRecoveryCoordinatorStopsAtEachFailedStage);
     RUN_TEST(TestRecoveryCoordinatorRejectsIncompleteOpsBeforeStarting);
     RUN_TEST(TestFillerClassificationRequiresCompleteFillerWords);
+    RUN_TEST(TestConfigReplyReadSkipsOneFillerOnlyReceive);
+    RUN_TEST(TestConfigReplyReadReturnsNonFillerImmediately);
+    RUN_TEST(TestConfigReplyReadRejectsZeroTransferImmediately);
+    RUN_TEST(TestConfigReplyReadStopsAtOverallDeadline);
+    RUN_TEST(TestConfigReplyReadStopsAfterSecondFiller);
+    RUN_TEST(TestConfigReplyReadRejectsReadErrorsAndOversize);
+    RUN_TEST(TestConfigReplyReadSkipsUnrelatedNonFillerReplies);
+    RUN_TEST(TestConfigReplyReadBoundsUnrelatedNonFillerReplies);
+    RUN_TEST(TestMatchingConfigReplyReadRejectsZeroTransferImmediately);
+    RUN_TEST(TestMatchingConfigReplyReadStopsAtOverallDeadline);
+    RUN_TEST(TestConfigReplyReadAccumulatesSplitReply);
+    RUN_TEST(TestConfigReplyReadAcceptsTrailingFillerWithoutAnotherRead);
     RUN_TEST(TestDrainRequiresSustainedQuiescence);
     RUN_TEST(TestDrainResetsQuietWindowAfterTraffic);
     RUN_TEST(TestDrainReportsReadErrorWithoutRetry);
@@ -1571,6 +2363,9 @@ int main(void)
     RUN_TEST(TestDrainDeadlineWinsAfterSlowRead);
     RUN_TEST(TestDrainPassesRemainingDeadlineToReads);
     RUN_TEST(TestDrainRejectsInvalidPolicy);
+    RUN_TEST(TestPCIeLinkInfoRejectsUnavailableAndOutOfRangeState);
+    RUN_TEST(TestPCIeLinkInfoMapsSupportedRateAndWidthIndexes);
+    RUN_TEST(TestCustomPCIeConfigRequiresSuccessfulNonDefaultRead);
     if(g_cFailures) {
         printf("%d test assertion(s) failed.\n", g_cFailures);
         return 1;

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -4,6 +4,13 @@
 #include "../leechcore/device_fpga_session.h"
 
 static int g_cFailures = 0;
+static int g_cTests = 0;
+
+#define RUN_TEST(test) \
+    do { \
+        (test)(); \
+        g_cTests++; \
+    } while(0)
 
 #define ASSERT_TRUE(value) \
     do { \
@@ -1516,58 +1523,58 @@ static VOID TestDrainRejectsInvalidPolicy(VOID)
 
 int main(void)
 {
-    TestCompleteAlignedReply();
-    TestCompleteUnalignedReply();
-    TestCompleteZeroValuedReply();
-    TestEmptyReplyFailsAndClearsOutput();
-    TestPartialReplyFailsAndClearsOutput();
-    TestWrongSourceReplyFailsAndClearsOutput();
-    TestV4IdentityRetriesAndPublishesCompleteReply();
-    TestV4IdentityFailureIsBoundedAndDoesNotPublish();
-    TestV4IdentityAcceptsExplicitZeroFpgaId();
-    TestV4IdentityRejectsLegacyMajorWithoutPublishing();
-    TestV3IdentityRequiresEveryIdentityCommand();
-    TestV3IdentityPublishesCompleteReply();
-    TestV3IdentityAcceptsExplicitZeroFpgaId();
-    TestTlpFrameIgnoresContinuationUntilFirst();
-    TestTlpFrameCompletesAfterExplicitFirst();
-    TestTlpFrameRestartsAtNewFirst();
-    TestTlpFrameRejectsShortAndOversizePackets();
-    TestTlpFrameAcceptsLegacyStreamWithoutFirst();
-    TestBoundedReadReturnsImmediateCompletion();
-    TestBoundedReadWaitsForPendingCompletion();
-    TestBoundedReadPendingForeverTimesOut();
-    TestBoundedReadReturnsSubmissionErrorWithoutPolling();
-    TestBoundedReadRejectsInvalidArguments();
-    TestWaitUsesEventWithoutPolling();
-    TestWaitFallsBackToPollingAfterEarlyEvent();
-    TestWaitCanBypassSignaledEventForPolling();
-    TestWaitEventTimeoutDoesNotPoll();
-    TestWaitCompletesWithoutBlockingDriverCall();
-    TestWaitPendingForeverTimesOutAtDeadline();
-    TestWaitReturnsDriverErrorWithoutRetry();
-    TestCloseCancelsReadPipeBeforeWaiting();
-    TestClosePendingForeverIsBoundedAndStillReleases();
-    TestCloseReportsAbortErrorAfterAttemptingCleanup();
-    TestConfigurePipeTimeoutsConfiguresBothDirections();
-    TestConfigurePipeTimeoutsReportsEitherFailure();
-    TestRecoveryCoordinatorExecutesOneOrderedAttempt();
-    TestRecoveryCoordinatorStopsAtEachFailedStage();
-    TestRecoveryCoordinatorRejectsIncompleteOpsBeforeStarting();
-    TestFillerClassificationRequiresCompleteFillerWords();
-    TestDrainRequiresSustainedQuiescence();
-    TestDrainResetsQuietWindowAfterTraffic();
-    TestDrainReportsReadErrorWithoutRetry();
-    TestDrainRejectsOversizedRead();
-    TestDrainEnforcesNonFillerByteLimit();
-    TestDrainEnforcesOverallDeadline();
-    TestDrainDeadlineWinsAfterSlowRead();
-    TestDrainPassesRemainingDeadlineToReads();
-    TestDrainRejectsInvalidPolicy();
+    RUN_TEST(TestCompleteAlignedReply);
+    RUN_TEST(TestCompleteUnalignedReply);
+    RUN_TEST(TestCompleteZeroValuedReply);
+    RUN_TEST(TestEmptyReplyFailsAndClearsOutput);
+    RUN_TEST(TestPartialReplyFailsAndClearsOutput);
+    RUN_TEST(TestWrongSourceReplyFailsAndClearsOutput);
+    RUN_TEST(TestV4IdentityRetriesAndPublishesCompleteReply);
+    RUN_TEST(TestV4IdentityFailureIsBoundedAndDoesNotPublish);
+    RUN_TEST(TestV4IdentityAcceptsExplicitZeroFpgaId);
+    RUN_TEST(TestV4IdentityRejectsLegacyMajorWithoutPublishing);
+    RUN_TEST(TestV3IdentityRequiresEveryIdentityCommand);
+    RUN_TEST(TestV3IdentityPublishesCompleteReply);
+    RUN_TEST(TestV3IdentityAcceptsExplicitZeroFpgaId);
+    RUN_TEST(TestTlpFrameIgnoresContinuationUntilFirst);
+    RUN_TEST(TestTlpFrameCompletesAfterExplicitFirst);
+    RUN_TEST(TestTlpFrameRestartsAtNewFirst);
+    RUN_TEST(TestTlpFrameRejectsShortAndOversizePackets);
+    RUN_TEST(TestTlpFrameAcceptsLegacyStreamWithoutFirst);
+    RUN_TEST(TestBoundedReadReturnsImmediateCompletion);
+    RUN_TEST(TestBoundedReadWaitsForPendingCompletion);
+    RUN_TEST(TestBoundedReadPendingForeverTimesOut);
+    RUN_TEST(TestBoundedReadReturnsSubmissionErrorWithoutPolling);
+    RUN_TEST(TestBoundedReadRejectsInvalidArguments);
+    RUN_TEST(TestWaitUsesEventWithoutPolling);
+    RUN_TEST(TestWaitFallsBackToPollingAfterEarlyEvent);
+    RUN_TEST(TestWaitCanBypassSignaledEventForPolling);
+    RUN_TEST(TestWaitEventTimeoutDoesNotPoll);
+    RUN_TEST(TestWaitCompletesWithoutBlockingDriverCall);
+    RUN_TEST(TestWaitPendingForeverTimesOutAtDeadline);
+    RUN_TEST(TestWaitReturnsDriverErrorWithoutRetry);
+    RUN_TEST(TestCloseCancelsReadPipeBeforeWaiting);
+    RUN_TEST(TestClosePendingForeverIsBoundedAndStillReleases);
+    RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
+    RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);
+    RUN_TEST(TestConfigurePipeTimeoutsReportsEitherFailure);
+    RUN_TEST(TestRecoveryCoordinatorExecutesOneOrderedAttempt);
+    RUN_TEST(TestRecoveryCoordinatorStopsAtEachFailedStage);
+    RUN_TEST(TestRecoveryCoordinatorRejectsIncompleteOpsBeforeStarting);
+    RUN_TEST(TestFillerClassificationRequiresCompleteFillerWords);
+    RUN_TEST(TestDrainRequiresSustainedQuiescence);
+    RUN_TEST(TestDrainResetsQuietWindowAfterTraffic);
+    RUN_TEST(TestDrainReportsReadErrorWithoutRetry);
+    RUN_TEST(TestDrainRejectsOversizedRead);
+    RUN_TEST(TestDrainEnforcesNonFillerByteLimit);
+    RUN_TEST(TestDrainEnforcesOverallDeadline);
+    RUN_TEST(TestDrainDeadlineWinsAfterSlowRead);
+    RUN_TEST(TestDrainPassesRemainingDeadlineToReads);
+    RUN_TEST(TestDrainRejectsInvalidPolicy);
     if(g_cFailures) {
         printf("%d test assertion(s) failed.\n", g_cFailures);
         return 1;
     }
-    printf("PASS: 47 FPGA session protocol cases.\n");
+    printf("PASS: %d FPGA session protocol cases.\n", g_cTests);
     return 0;
 }

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -355,6 +355,106 @@ static VOID TestPCIeConfigBatchBuilderPreservesSingleDwordRequest(VOID)
     ASSERT_EQ(cbBatch, 0);
 }
 
+#define PCIE_CONFIG_BATCH_REPLY_SIZE \
+    (DEVICE_FPGA_SESSION_PCIE_CONFIG_BATCH_DWORDS * 32)
+
+typedef struct tdPCIE_CONFIG_BATCH_REPLY_SCRIPT {
+    BYTE apbReply[9][PCIE_CONFIG_BATCH_REPLY_SIZE];
+    DWORD cReplies;
+    DWORD cCalls;
+} PCIE_CONFIG_BATCH_REPLY_SCRIPT, *PPCIE_CONFIG_BATCH_REPLY_SCRIPT;
+
+static VOID BuildPCIeConfigBatchReply(
+    _Out_writes_(PCIE_CONFIG_BATCH_REPLY_SIZE) PBYTE pbReply,
+    _In_ DWORD iStartDWord,
+    _In_ BYTE bOverride
+)
+{
+    DWORD i, oByte, dwStatus = 0xe0000111;
+    DWORD dwMeta, dwDataLo, dwDataHi;
+    for(i = 0; i < DEVICE_FPGA_SESSION_PCIE_CONFIG_BATCH_DWORDS; i++) {
+        oByte = (iStartDWord + i) * sizeof(DWORD);
+        dwMeta = 0x08002a00 | ((iStartDWord + i) << 16);
+        dwDataLo =
+            ((DWORD)(bOverride ? bOverride : ((oByte + 1) & 0xff)) << 24) |
+            ((DWORD)(bOverride ? bOverride : (oByte & 0xff)) << 16) |
+            0x2c00;
+        dwDataHi =
+            ((DWORD)(bOverride ? bOverride : ((oByte + 3) & 0xff)) << 24) |
+            ((DWORD)(bOverride ? bOverride : ((oByte + 2) & 0xff)) << 16) |
+            0x2e00;
+        ZeroMemory(pbReply + (i * 32), 32);
+        memcpy(pbReply + (i * 32), &dwStatus, sizeof(dwStatus));
+        memcpy(pbReply + (i * 32) + 4, &dwMeta, sizeof(dwMeta));
+        memcpy(pbReply + (i * 32) + 8, &dwDataLo, sizeof(dwDataLo));
+        memcpy(pbReply + (i * 32) + 12, &dwDataHi, sizeof(dwDataHi));
+    }
+}
+
+static ULONG WINAPI ScriptedPCIeConfigBatchRead(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _Out_writes_(cbBuffer) PUCHAR pbBuffer,
+    _In_ ULONG cbBuffer,
+    _Out_ PULONG pcbTransferred,
+    _In_opt_ LPOVERLAPPED pOverlapped
+)
+{
+    PPCIE_CONFIG_BATCH_REPLY_SCRIPT pScript =
+        (PPCIE_CONFIG_BATCH_REPLY_SCRIPT)hFTDI;
+    UNREFERENCED_PARAMETER(pOverlapped);
+    if((ucPipeID != 0x82) ||
+       (cbBuffer < PCIE_CONFIG_BATCH_REPLY_SIZE)) {
+        *pcbTransferred = 0;
+        return 1;
+    }
+    if(pScript->cCalls >= pScript->cReplies) {
+        *pcbTransferred = 0;
+        return 0;
+    }
+    memcpy(pbBuffer, pScript->apbReply[pScript->cCalls],
+        PCIE_CONFIG_BATCH_REPLY_SIZE);
+    pScript->cCalls++;
+    *pcbTransferred = PCIE_CONFIG_BATCH_REPLY_SIZE;
+    return 0;
+}
+
+static VOID TestPCIeConfigBatchReadDoesNotAdvanceOnShiftedStaleReply(VOID)
+{
+    PCIE_CONFIG_BATCH_REPLY_SCRIPT Script = { 0 };
+    BYTE pbBuffer[0x1000] = { 0 };
+    BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
+    BYTE pbCoverage[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
+    DWORD i, iBatch, cbRead;
+    BuildPCIeConfigBatchReply(Script.apbReply[0], 112, 0xee);
+    for(iBatch = 0; iBatch < 8; iBatch++) {
+        BuildPCIeConfigBatchReply(
+            Script.apbReply[iBatch + 1], iBatch * 16, 0);
+    }
+    Script.cReplies = 9;
+    for(iBatch = 0; iBatch < 8; iBatch++) {
+        cbRead = 0;
+        ASSERT_TRUE(DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
+            &Script,
+            pbBuffer,
+            sizeof(pbBuffer),
+            &cbRead,
+            ScriptedPCIeConfigBatchRead,
+            iBatch * 16,
+            16,
+            pbResult,
+            pbCoverage,
+            DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+            NULL,
+            NULL));
+    }
+    ASSERT_EQ(Script.cCalls, 9);
+    ASSERT_TRUE(DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, 0));
+    for(i = 0; i < sizeof(pbResult); i++) {
+        ASSERT_EQ(pbResult[i], i & 0xff);
+    }
+}
+
 typedef struct tdPCIE_CONFIG_READ_SCRIPT {
     BOOL afSuccess[2];
     BYTE abWrite[2];
@@ -410,11 +510,13 @@ static VOID TestPCIeConfigRetryStopsAfterTwoFailures(VOID)
 {
     PCIE_CONFIG_READ_SCRIPT Script = { { FALSE, FALSE }, { 0xaa, 0x22 }, 0, TRUE };
     BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE];
+    BYTE pbExpected[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
     memset(pbResult, 0xff, sizeof(pbResult));
     ASSERT_FALSE(DeviceFPGA_Session_ReadPCIeConfigWithRetry(
         &Script, ScriptedPCIeConfigReadAttempt, pbResult, 0));
     ASSERT_EQ(Script.cCalls, 2);
     ASSERT_TRUE(Script.fSecondOutputWasCleared);
+    ASSERT_BYTES(pbResult, pbExpected, sizeof(pbResult));
 }
 
 static VOID TestPCIeConfigRetryRejectsOutOfRangeRequestWithoutAttempt(VOID)
@@ -2306,6 +2408,7 @@ int main(void)
     RUN_TEST(TestPCIeConfigBatchSizingBoundsRepliesBelowTransportBoundary);
     RUN_TEST(TestPCIeConfigBatchBuilderKeepsRealRequestsBelowBoundary);
     RUN_TEST(TestPCIeConfigBatchBuilderPreservesSingleDwordRequest);
+    RUN_TEST(TestPCIeConfigBatchReadDoesNotAdvanceOnShiftedStaleReply);
     RUN_TEST(TestPCIeConfigRetryReturnsFirstAttemptSuccess);
     RUN_TEST(TestPCIeConfigRetryClearsOutputBeforeSecondAttempt);
     RUN_TEST(TestPCIeConfigRetryStopsAfterTwoFailures);

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -360,6 +360,7 @@ static VOID TestPCIeConfigBatchBuilderPreservesSingleDwordRequest(VOID)
 
 typedef struct tdPCIE_CONFIG_BATCH_REPLY_SCRIPT {
     BYTE apbReply[9][PCIE_CONFIG_BATCH_REPLY_SIZE];
+    DWORD acbReply[9];
     DWORD cReplies;
     DWORD cCalls;
 } PCIE_CONFIG_BATCH_REPLY_SCRIPT, *PPCIE_CONFIG_BATCH_REPLY_SCRIPT;
@@ -402,9 +403,13 @@ static ULONG WINAPI ScriptedPCIeConfigBatchRead(
 {
     PPCIE_CONFIG_BATCH_REPLY_SCRIPT pScript =
         (PPCIE_CONFIG_BATCH_REPLY_SCRIPT)hFTDI;
+    DWORD cbReply;
     UNREFERENCED_PARAMETER(pOverlapped);
-    if((ucPipeID != 0x82) ||
-       (cbBuffer < PCIE_CONFIG_BATCH_REPLY_SIZE)) {
+    cbReply = (pScript->cCalls < pScript->cReplies) &&
+        pScript->acbReply[pScript->cCalls] ?
+        pScript->acbReply[pScript->cCalls] :
+        PCIE_CONFIG_BATCH_REPLY_SIZE;
+    if((ucPipeID != 0x82) || (cbBuffer < cbReply)) {
         *pcbTransferred = 0;
         return 1;
     }
@@ -413,9 +418,9 @@ static ULONG WINAPI ScriptedPCIeConfigBatchRead(
         return 0;
     }
     memcpy(pbBuffer, pScript->apbReply[pScript->cCalls],
-        PCIE_CONFIG_BATCH_REPLY_SIZE);
+        cbReply);
     pScript->cCalls++;
-    *pcbTransferred = PCIE_CONFIG_BATCH_REPLY_SIZE;
+    *pcbTransferred = cbReply;
     return 0;
 }
 
@@ -452,6 +457,63 @@ static VOID TestPCIeConfigBatchReadDoesNotAdvanceOnShiftedStaleReply(VOID)
     ASSERT_TRUE(DeviceFPGA_Session_IsPCIeConfigComplete(pbCoverage, 0));
     for(i = 0; i < sizeof(pbResult); i++) {
         ASSERT_EQ(pbResult[i], i & 0xff);
+    }
+}
+
+static VOID TestPCIeConfigBatchReadRejectsStaleFutureCoverageAfterMissingReply(VOID)
+{
+    PCIE_CONFIG_BATCH_REPLY_SCRIPT Script = { 0 };
+    BYTE pbBuffer[0x1000] = { 0 };
+    BYTE pbResult[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
+    BYTE pbCoverage[DEVICE_FPGA_SESSION_PCIE_CONFIG_SIZE] = { 0 };
+    DWORD i, iBatch, cbRead = 0xaa;
+    BuildPCIeConfigBatchReply(Script.apbReply[0], 112, 0xee);
+    for(iBatch = 0; iBatch < 7; iBatch++) {
+        BuildPCIeConfigBatchReply(
+            Script.apbReply[iBatch + 1], iBatch * 16, 0);
+    }
+    BuildPCIeConfigReplyRecord(Script.apbReply[8], 0x44332211);
+    Script.acbReply[8] = 32;
+    Script.cReplies = 9;
+    for(iBatch = 0; iBatch < 7; iBatch++) {
+        cbRead = 0;
+        ASSERT_TRUE(DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
+            &Script,
+            pbBuffer,
+            sizeof(pbBuffer),
+            &cbRead,
+            ScriptedPCIeConfigBatchRead,
+            iBatch * 16,
+            16,
+            pbResult,
+            pbCoverage,
+            DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+            NULL,
+            NULL));
+    }
+    cbRead = 0xaa;
+    ASSERT_FALSE(DeviceFPGA_Session_ReadPCIeConfigBatchMatching(
+        &Script,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        ScriptedPCIeConfigBatchRead,
+        112,
+        16,
+        pbResult,
+        pbCoverage,
+        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
+        NULL,
+        NULL));
+    ASSERT_EQ(cbRead, 0);
+    ASSERT_EQ(Script.cCalls, 9);
+    for(i = 0; i < 112 * sizeof(DWORD); i++) {
+        ASSERT_EQ(pbResult[i], i & 0xff);
+        ASSERT_EQ(pbCoverage[i], 1);
+    }
+    for(; i < sizeof(pbResult); i++) {
+        ASSERT_EQ(pbResult[i], 0);
+        ASSERT_EQ(pbCoverage[i], 0);
     }
 }
 
@@ -1495,6 +1557,59 @@ static VOID TestCloseReportsAbortErrorAfterAttemptingCleanup(VOID)
     ASSERT_EQ(Script.cReleaseCalls, 1);
 }
 
+typedef struct tdPIPE_TIMEOUT_SCRIPT {
+    BYTE pbPipe[2];
+    ULONG pulTimeout[2];
+    DWORD cCalls;
+    ULONG ulRxStatus;
+    ULONG ulTxStatus;
+} PIPE_TIMEOUT_SCRIPT, *PPIPE_TIMEOUT_SCRIPT;
+
+static ULONG WINAPI ScriptedSetPipeTimeout(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _In_ ULONG ulTimeoutInMs
+)
+{
+    PPIPE_TIMEOUT_SCRIPT pScript = (PPIPE_TIMEOUT_SCRIPT)hFTDI;
+    DWORD i = pScript->cCalls++;
+    if(i < 2) {
+        pScript->pbPipe[i] = ucPipeID;
+        pScript->pulTimeout[i] = ulTimeoutInMs;
+    }
+    return (ucPipeID == 0x82) ? pScript->ulRxStatus : pScript->ulTxStatus;
+}
+
+static VOID TestConfigurePipeTimeoutsConfiguresBothDirections(VOID)
+{
+    PIPE_TIMEOUT_SCRIPT Script = { 0 };
+    ASSERT_TRUE(DeviceFPGA_Session_ConfigurePipeTimeouts(
+        &Script,
+        DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS,
+        ScriptedSetPipeTimeout));
+    ASSERT_EQ(Script.cCalls, 2);
+    ASSERT_EQ(Script.pbPipe[0], 0x82);
+    ASSERT_EQ(Script.pbPipe[1], 0x02);
+    ASSERT_EQ(Script.pulTimeout[0], DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS);
+    ASSERT_EQ(Script.pulTimeout[1], DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS);
+}
+
+static VOID TestConfigurePipeTimeoutsReportsEitherFailure(VOID)
+{
+    PIPE_TIMEOUT_SCRIPT RxFailure = { { 0 }, { 0 }, 0, 1, 0 };
+    PIPE_TIMEOUT_SCRIPT TxFailure = { { 0 }, { 0 }, 0, 0, 1 };
+    ASSERT_FALSE(DeviceFPGA_Session_ConfigurePipeTimeouts(
+        &RxFailure,
+        DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS,
+        ScriptedSetPipeTimeout));
+    ASSERT_EQ(RxFailure.cCalls, 2);
+    ASSERT_FALSE(DeviceFPGA_Session_ConfigurePipeTimeouts(
+        &TxFailure,
+        DEVICE_FPGA_SESSION_WAIT_TIMEOUT_MS,
+        ScriptedSetPipeTimeout));
+    ASSERT_EQ(TxFailure.cCalls, 2);
+}
+
 #define RECOVERY_EVENT_QUIESCE      1
 #define RECOVERY_EVENT_REOPEN       2
 #define RECOVERY_EVENT_INITIALIZE   3
@@ -1647,12 +1762,7 @@ typedef struct tdCONFIG_REPLY_READ_SCRIPT {
     DWORD pcbReply[2];
     DWORD cCalls;
     DWORD dwReadDelayMs;
-    DWORD iFailureCall;
-    DWORD iOversizeCall;
     QWORD qwNow;
-    UCHAR ucLastPipe;
-    DWORD cbLastBuffer;
-    BOOL fSawOverlapped;
 } CONFIG_REPLY_READ_SCRIPT, *PCONFIG_REPLY_READ_SCRIPT;
 
 static ULONG WINAPI ScriptedConfigReplyRead(
@@ -1667,18 +1777,9 @@ static ULONG WINAPI ScriptedConfigReplyRead(
     PCONFIG_REPLY_READ_SCRIPT pScript =
         (PCONFIG_REPLY_READ_SCRIPT)hFTDI;
     DWORD iCall = pScript->cCalls++;
-    pScript->ucLastPipe = ucPipeID;
-    pScript->cbLastBuffer = cbBuffer;
-    pScript->fSawOverlapped |= pOverlapped != NULL;
+    UNREFERENCED_PARAMETER(ucPipeID);
+    UNREFERENCED_PARAMETER(pOverlapped);
     pScript->qwNow += pScript->dwReadDelayMs;
-    if(iCall + 1 == pScript->iFailureCall) {
-        *pcbTransferred = 0;
-        return 1;
-    }
-    if(iCall + 1 == pScript->iOversizeCall) {
-        *pcbTransferred = cbBuffer + 1;
-        return 0;
-    }
     if(iCall >= 2 || pScript->pcbReply[iCall] > cbBuffer) {
         *pcbTransferred = 0;
         return 1;
@@ -1718,161 +1819,6 @@ static VOID SetConfigReplyRecord(
     };
     memcpy(pb, pbRecord, sizeof(pbRecord));
     *pcb = sizeof(pbRecord);
-}
-
-static VOID TestConfigReplyReadSkipsOneFillerOnlyReceive(VOID)
-{
-    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
-    BYTE pbBuffer[64] = { 0 };
-    BYTE pbResult[3] = { 0 };
-    BYTE pbExpected[3] = { 0x04, 0x13, 0x04 };
-    DWORD cbRead = 0;
-    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
-    SetConfigReplyRecord(Script.pbReply[1], &Script.pcbReply[1]);
-    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReply(
-        &Script,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(Script.cCalls, 2);
-    ASSERT_EQ(Script.ucLastPipe, 0x82);
-    ASSERT_EQ(Script.cbLastBuffer, sizeof(pbBuffer));
-    ASSERT_FALSE(Script.fSawOverlapped);
-    ASSERT_EQ(cbRead, Script.pcbReply[1]);
-    ASSERT_BYTES(pbBuffer, Script.pbReply[1], cbRead);
-    ASSERT_TRUE(DeviceFPGA_Session_ParseConfigReply(
-        pbBuffer,
-        cbRead,
-        0x0008,
-        pbResult,
-        sizeof(pbResult),
-        0x0003));
-    ASSERT_BYTES(pbResult, pbExpected, sizeof(pbResult));
-}
-
-static VOID TestConfigReplyReadReturnsNonFillerImmediately(VOID)
-{
-    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
-    BYTE pbBuffer[64] = { 0 };
-    DWORD cbRead = 0;
-    SetConfigReplyRecord(Script.pbReply[0], &Script.pcbReply[0]);
-    ASSERT_TRUE(DeviceFPGA_Session_ReadConfigReply(
-        &Script,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(Script.cCalls, 1);
-    ASSERT_EQ(cbRead, Script.pcbReply[0]);
-    ASSERT_BYTES(pbBuffer, Script.pbReply[0], cbRead);
-}
-
-static VOID TestConfigReplyReadRejectsZeroTransferImmediately(VOID)
-{
-    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
-    BYTE pbBuffer[64] = { 0 };
-    DWORD cbRead = 0xaa;
-    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
-        &Script,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(Script.cCalls, 1);
-    ASSERT_EQ(cbRead, 0);
-}
-
-static VOID TestConfigReplyReadStopsAtOverallDeadline(VOID)
-{
-    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
-    BYTE pbBuffer[64] = { 0 };
-    DWORD cbRead = 0xaa;
-    Script.dwReadDelayMs = 100;
-    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
-    SetConfigReplyRecord(Script.pbReply[1], &Script.pcbReply[1]);
-    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
-        &Script,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        100,
-        &Script,
-        ScriptedConfigReplyTick));
-    ASSERT_EQ(Script.cCalls, 1);
-    ASSERT_EQ(cbRead, 0);
-}
-
-static VOID TestConfigReplyReadStopsAfterSecondFiller(VOID)
-{
-    CONFIG_REPLY_READ_SCRIPT Script = { 0 };
-    BYTE pbBuffer[64] = { 0 };
-    DWORD cbRead = 0xaa;
-    SetConfigReplyFiller(Script.pbReply[0], &Script.pcbReply[0]);
-    SetConfigReplyFiller(Script.pbReply[1], &Script.pcbReply[1]);
-    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
-        &Script,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(Script.cCalls, 2);
-    ASSERT_EQ(cbRead, 0);
-}
-
-static VOID TestConfigReplyReadRejectsReadErrorsAndOversize(VOID)
-{
-    CONFIG_REPLY_READ_SCRIPT Failure = { 0 };
-    CONFIG_REPLY_READ_SCRIPT Oversize = { 0 };
-    BYTE pbBuffer[64] = { 0 };
-    DWORD cbRead = 0xaa;
-    Failure.iFailureCall = 1;
-    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
-        &Failure,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(Failure.cCalls, 1);
-    ASSERT_EQ(cbRead, 0);
-    Oversize.iOversizeCall = 1;
-    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
-        &Oversize,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(Oversize.cCalls, 1);
-    ASSERT_EQ(cbRead, 0);
-    ASSERT_FALSE(DeviceFPGA_Session_ReadConfigReply(
-        NULL,
-        pbBuffer,
-        sizeof(pbBuffer),
-        &cbRead,
-        ScriptedConfigReplyRead,
-        DEVICE_FPGA_SESSION_CONFIG_REPLY_TIMEOUT_MS,
-        NULL,
-        NULL));
-    ASSERT_EQ(cbRead, 0);
 }
 
 typedef struct tdMATCHING_CONFIG_REPLY_SCRIPT {
@@ -2409,6 +2355,7 @@ int main(void)
     RUN_TEST(TestPCIeConfigBatchBuilderKeepsRealRequestsBelowBoundary);
     RUN_TEST(TestPCIeConfigBatchBuilderPreservesSingleDwordRequest);
     RUN_TEST(TestPCIeConfigBatchReadDoesNotAdvanceOnShiftedStaleReply);
+    RUN_TEST(TestPCIeConfigBatchReadRejectsStaleFutureCoverageAfterMissingReply);
     RUN_TEST(TestPCIeConfigRetryReturnsFirstAttemptSuccess);
     RUN_TEST(TestPCIeConfigRetryClearsOutputBeforeSecondAttempt);
     RUN_TEST(TestPCIeConfigRetryStopsAfterTwoFailures);
@@ -2441,16 +2388,12 @@ int main(void)
     RUN_TEST(TestCloseCancelsReadPipeBeforeWaiting);
     RUN_TEST(TestClosePendingForeverIsBoundedAndStillReleases);
     RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
+    RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);
+    RUN_TEST(TestConfigurePipeTimeoutsReportsEitherFailure);
     RUN_TEST(TestRecoveryCoordinatorExecutesOneOrderedAttempt);
     RUN_TEST(TestRecoveryCoordinatorStopsAtEachFailedStage);
     RUN_TEST(TestRecoveryCoordinatorRejectsIncompleteOpsBeforeStarting);
     RUN_TEST(TestFillerClassificationRequiresCompleteFillerWords);
-    RUN_TEST(TestConfigReplyReadSkipsOneFillerOnlyReceive);
-    RUN_TEST(TestConfigReplyReadReturnsNonFillerImmediately);
-    RUN_TEST(TestConfigReplyReadRejectsZeroTransferImmediately);
-    RUN_TEST(TestConfigReplyReadStopsAtOverallDeadline);
-    RUN_TEST(TestConfigReplyReadStopsAfterSecondFiller);
-    RUN_TEST(TestConfigReplyReadRejectsReadErrorsAndOversize);
     RUN_TEST(TestConfigReplyReadSkipsUnrelatedNonFillerReplies);
     RUN_TEST(TestConfigReplyReadBoundsUnrelatedNonFillerReplies);
     RUN_TEST(TestMatchingConfigReplyReadRejectsZeroTransferImmediately);


### PR DESCRIPTION
## Problem

`DeviceFPGA_PCIeCfgSpaceCoreRead()` issued 32-DWORD request batches, then parsed whatever the next single pipe read returned directly into one shared `0x200` output buffer.

A 32-DWORD reply can cross the FT601's effective 1 KiB receive boundary and lose its final framed result. Because every batch wrote into the same buffer with no record of which bytes had actually been answered, a reply belonging to a later batch could satisfy an earlier request, and a short or split read was indistinguishable from a complete one.

## Summary

- Keep each configuration request batch inside the FT601 receive boundary (16 DWORDs per batch), and parse each batch into a fresh per-batch result and coverage buffer, so data from another batch cannot satisfy the current request.
- Accumulate replies across bounded, timeout-limited reads, and accept a batch only once the requested DWORD range has complete source and address coverage.
- Publish only the requested byte range after that batch completes; keep whole-read retry and zero the output on failure so callers cannot observe partial data.
- Stop treating a trailing filler-only tail as a truncated record in `ParseConfigReply()` and `ParseV3Identity()`.
- Fail `LC_CMD_FPGA_PCIECFGSPACE` and `LC_CMD_FPGA_CFGREGCFG`/`CFGREGPCIE` closed on error. The previous code set `*ppbDataOut` to an allocated buffer and then returned FALSE, leaking the allocation.
- Retry `DeviceFPGA_GetPHYv4()` once and commit `ctx->phy` only on full success, instead of leaving it partially updated.
- Print the FPGA config-register header only when the corresponding read succeeds, and gate the `FWCUST` marker on a successful configuration read.
- Replace `DeviceFPGA_PHY_GetPCIeGen()`/`DeviceFPGA_PHY_GetLinkWidth()` with a single validated link-info helper.
- Count executed session tests at runtime instead of printing a hardcoded total.

## User-visible output change

When PHY link state is unsupported, verbose device-open output now reports `PCIe unknown`. Previous code derived `PCIe gen1 x1` from zero-initialized PHY state even though no valid link information was available.

## Defect reproduction, before and after

Built and tested on a Linux ARM64 host and a Windows 11 x64 host. Tested against a Windows 11 x64 target and a Linux x64 target. For the before-and-after comparison, the host, target, and FPGA device were held constant; only `leechcore.dll` changed. The Before column used packaged v2.23.

| Hardware test | Before | After |
| --- | --- | --- |
| First `CFGREGCFG` response in a fresh process | 10/20 sessions returned the expected non-empty block; the other 10/20 returned an empty block while still reporting success. | 20/20 sessions returned the expected 40-byte block: 0/20 empty responses, 20/20 clean closes. |
| Fresh link-state reporting | 7/50 sessions reported `PCIe gen1 x1`, the zero-initialized fallback, instead of the actual link; 43/50 reported Gen2 x1. | 50/50 sessions reported Gen2 x1 and completed the one-page read with no transport diagnostics. |

Both rows are the same class of defect: a failed read published a plausible-looking value instead of reporting failure. The configuration read returned success over a range the device had not answered, and the verbose banner derived `PCIe gen1 x1` from zeroed PHY state. The `GetPHYv4()` retry removes the intermittent PHY failure, and the new unknown-link output makes any residual case visible rather than silently wrong.

These are correctness comparisons. Timing ranges overlapped and are not used as a performance claim.

## Validation

- Rebased onto current master.
- Windows x64 and Win32: the FPGA session suite reports 76 measured cases on each architecture.
- Windows x64 LeechCore library rebuild passed.
- Regression coverage includes a stale batch 7 arriving while batch 0 is pending, valid batches 0-6, and an unrelated frame arriving after batch 7 is issued.
- The final commit is formatting only, collapsing wrapped conditions in `device_fpga.c` to match surrounding style. It is token-identical to its parent and can be dropped if unwanted.

## Interaction with #90 and #91

This change is independent of #90 and #91; it touches the configuration-space path rather than the overlapped-read lifecycle.

#89 and #91 now share the exact runner-only ancestor `6df9749` (`test(fpga): report executed session cases`); stacked #90 inherits it through #91. Git simulations of all six landing permutations completed without conflicts and produced the same final tree (`1b7c1dc`). No rebase or manual test-runner resolution is needed in any order.

- Windows x64 and Win32: LeechCore and all three test projects rebuild on the composed tree; the combined session suite reports 87 measured cases on each architecture; read-policy and scatter-contract suites pass.
- Linux x86_64: read-policy tests, 5 FPGA session wait cases, and the inline framing code-generation check pass.
- ARM64 Linux: the same suites pass, and the combined shared library builds as an ELF64 AArch64 object.
- #90 remains intentionally stacked on #91, so the configured review order is #91 then #90. #89 can land before, between, or after that stack.

## Additional hardware validation

The combined tree was built and tested on a Windows 11 x64 host against a Windows 11 x64 target and a Linux x64 target.

- 150 sustained and 150 fresh-process command invocations completed across `pciecfgspace`, `cfgregpcie`, and `cfgregcfg`.
- All returned the expected sizes and content.
- Zero open, close, timeout, process, or semantic failures occurred.

An earlier focused run on this branch's production code returned expected sizes and content for 150/150 fresh-process and 150/150 sustained invocations. Four of those sessions hit the close-status defect that #91 fixes; their command results were still correct, and the combined run above closed cleanly throughout.

Contribution offered under the 0BSD license.
