### PR TITLE
fix(fpga): safely tear down active overlapped reads

### DIFF
--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -2317,16 +2317,14 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
             ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
         }
     } else if(ctx->async2.fReadPending) {
-        fResult = ctx->dev.pfnFT_AbortPipe &&
-            (ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82) == DEVICE_FPGA_SESSION_FT_OK);
+        fResult = ctx->dev.pfnFT_AbortPipe && (ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82) == DEVICE_FPGA_SESSION_FT_OK);
     }
     status = ctx->dev.pfnFT_Close(ctx->dev.hFTDI);
     if(status) {
         return FALSE;
     }
     ctx->dev.hFTDI = NULL;
-    if(!fOverlappedReleased &&
-       (ctx->async2.fOverlappedInitialized || ctx->async2.fReadPending)) {
+    if(!fOverlappedReleased && (ctx->async2.fOverlappedInitialized || ctx->async2.fReadPending)) {
         ctx->async2.fOverlappedInitialized = FALSE;
         ctx->async2.fReadPending = FALSE;
         ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -2303,11 +2303,9 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
         ctx->async2.fOverlappedInitialized = FALSE;
         ctx->async2.fReadPending = FALSE;
         ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
-    } else if(ctx->dev.pfnFT_AbortPipe) {
-        fResult &= ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82) == DEVICE_FPGA_SESSION_FT_OK;
-        fResult &= ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x02) == DEVICE_FPGA_SESSION_FT_OK;
-    } else {
-        fResult = FALSE;
+    } else if(ctx->async2.fReadPending) {
+        fResult = ctx->dev.pfnFT_AbortPipe &&
+            (ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82) == DEVICE_FPGA_SESSION_FT_OK);
     }
     status = ctx->dev.pfnFT_Close(ctx->dev.hFTDI);
     if(status) {
@@ -2562,6 +2560,7 @@ static DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_FTDI_ReadPipeBounded(_In_ PDEV
         &ctx->async2.oOverlapped,
         ctx->dev.pfnFT_ReadPipe,
         ctx->dev.pfnFT_GetOverlappedResult,
+        &ctx->async2.fReadPending,
         !ctx->fAdaptivePollingWait,
         dwTimeoutMs,
         DEVICE_FPGA_SESSION_WAIT_POLL_MS,

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -2290,9 +2290,10 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
     PDEVICE_CONTEXT_FPGA ctx = pRecovery->ctx;
     if(!ctx->dev.hFTDI) { return TRUE; }
     if(ctx->async2.fOverlappedInitialized) {
-        fResult = DeviceFPGA_Session_CloseOverlapped(
+        fResult = DeviceFPGA_Session_TeardownOverlapped(
             ctx->dev.hFTDI,
             &ctx->async2.oOverlapped,
+            ctx->async2.fReadPending,
             ctx->dev.pfnFT_AbortPipe,
             ctx->dev.pfnFT_GetOverlappedResult,
             ctx->dev.pfnFT_ReleaseOverlapped,

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -216,6 +216,7 @@ typedef struct tdFPGA_NEWASYNC2_CONTEXT {
     BOOL fEnabled;
     BOOL fOldAsync;
     BOOL fOverlappedInitialized;
+    BOOL fReadPending;
     BOOL fTransportError;
     OVERLAPPED oOverlapped;
     // below are only used for the new async (algo=0,1) mode:
@@ -1036,6 +1037,7 @@ ftdi_retry_old:
         }
     }
     ctx->async2.fOverlappedInitialized = ctx->dev.pfnFT_GetOverlappedResult && ctx->dev.pfnFT_InitializeOverlapped && ctx->dev.pfnFT_ReleaseOverlapped && !ctx->dev.pfnFT_InitializeOverlapped(ctx->dev.hFTDI, &ctx->async2.oOverlapped);
+    ctx->async2.fReadPending = FALSE;
     ctx->async2.fEnabled = ctx->async2.fOverlappedInitialized;
     ctx->dev.fInitialized = TRUE;
     DeviceFPGA_Initialize_LinuxMultiHandle_LockAcquire(ctx->qwDeviceIndex);
@@ -1317,9 +1319,10 @@ VOID DeviceFPGA_Close(_Inout_ PLC_CONTEXT ctxLC)
     ctx->fTransportSetup = FALSE;
     ctx->fTransportRecoveryInProgress = FALSE;
     if(ctx->async2.fOverlappedInitialized) {
-        DeviceFPGA_Session_CloseOverlapped(
+        DeviceFPGA_Session_TeardownOverlapped(
             ctx->dev.hFTDI,
             &ctx->async2.oOverlapped,
+            ctx->async2.fReadPending,
             ctx->dev.pfnFT_AbortPipe,
             ctx->dev.pfnFT_GetOverlappedResult,
             ctx->dev.pfnFT_ReleaseOverlapped,
@@ -1328,6 +1331,7 @@ VOID DeviceFPGA_Close(_Inout_ PLC_CONTEXT ctxLC)
             NULL
         );
         ctx->async2.fOverlappedInitialized = FALSE;
+        ctx->async2.fReadPending = FALSE;
         ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
     }
 #ifdef WIN32
@@ -2296,6 +2300,7 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
             NULL,
             NULL);
         ctx->async2.fOverlappedInitialized = FALSE;
+        ctx->async2.fReadPending = FALSE;
         ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
     } else if(ctx->dev.pfnFT_AbortPipe) {
         fResult &= ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82) == DEVICE_FPGA_SESSION_FT_OK;
@@ -2329,6 +2334,7 @@ static BOOL DeviceFPGA_FTDI_RecoveryInitializeOverlapped(_Inout_ PVOID pvContext
     ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
     status = ctx->dev.pfnFT_InitializeOverlapped(ctx->dev.hFTDI, &ctx->async2.oOverlapped);
     ctx->async2.fOverlappedInitialized = status == DEVICE_FPGA_SESSION_FT_OK;
+    ctx->async2.fReadPending = FALSE;
     return ctx->async2.fOverlappedInitialized;
 }
 
@@ -2579,6 +2585,7 @@ static DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_FTDI_WaitActiveRead(_In_ PDEVI
         DeviceFPGA_FTDI_Sleep);
     if(Result.outcome == DEVICE_FPGA_SESSION_WAIT_COMPLETED) {
         *pcbRead = Result.cbTransferred;
+        ctx->async2.fReadPending = FALSE;
     }
     return Result;
 }
@@ -3713,7 +3720,15 @@ VOID DeviceFPGA_Async2_ReadScatter_DoWork(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_C
         }
         // START OVERLAPPED READ:
         if(fAsync) {
-            status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, ctx->rxbuf.pb + ctx->rxbuf.cb, cbMAX_READSIZE, &cbRead, &ctx->async2.oOverlapped);
+            status = DeviceFPGA_Session_StartOverlappedRead(
+                ctx->dev.hFTDI,
+                0x82,
+                ctx->rxbuf.pb + ctx->rxbuf.cb,
+                cbMAX_READSIZE,
+                &cbRead,
+                &ctx->async2.oOverlapped,
+                ctx->dev.pfnFT_ReadPipe,
+                &ctx->async2.fReadPending);
             if(status && (status != FT_IO_PENDING)) {
                 ctx->async2.fTransportError = TRUE;
                 DeviceFPGA_FTDI_RxRecover(ctxLC, ctx, status, FALSE);
@@ -3807,7 +3822,15 @@ VOID DeviceFPGA_Async2_ReadOnlyFast_DoWork(_In_ PLC_CONTEXT ctxLC, _In_ PDEVICE_
         }
         // START OVERLAPPED READ:
         if(fAsync) {
-            status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, ctx->rxbuf.pb + ctx->rxbuf.cb, ctx->perf.ASYNC_MAX_READSIZE, &cbRead, &ctx->async2.oOverlapped);
+            status = DeviceFPGA_Session_StartOverlappedRead(
+                ctx->dev.hFTDI,
+                0x82,
+                ctx->rxbuf.pb + ctx->rxbuf.cb,
+                ctx->perf.ASYNC_MAX_READSIZE,
+                &cbRead,
+                &ctx->async2.oOverlapped,
+                ctx->dev.pfnFT_ReadPipe,
+                &ctx->async2.fReadPending);
             if(status && (status != FT_IO_PENDING)) {
                 DeviceFPGA_FTDI_RxRecover(ctxLC, ctx, status, FALSE);
                 return;
@@ -4140,7 +4163,15 @@ BOOL DeviceFPGA_SynchOldAsync_RxTlpAsynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDE
         cbBuffer += cbRead;
         // 1: submit async read (if target read is large enough to gain from it)
         if(fAsync) {
-            status = ctx->dev.pfnFT_ReadPipe(ctx->dev.hFTDI, 0x82, pbBuffer + cbBuffer, cbReadMax, &cbRead, &ctx->async2.oOverlapped);
+            status = DeviceFPGA_Session_StartOverlappedRead(
+                ctx->dev.hFTDI,
+                0x82,
+                pbBuffer + cbBuffer,
+                cbReadMax,
+                &cbRead,
+                &ctx->async2.oOverlapped,
+                ctx->dev.pfnFT_ReadPipe,
+                &ctx->async2.fReadPending);
             if(status && (status != FT_IO_PENDING)) {
                 fTransportError = TRUE;
                 DeviceFPGA_FTDI_RxRecover(ctxLC, ctx, status, FALSE);
@@ -4196,9 +4227,11 @@ BOOL DeviceFPGA_SynchOldAsync_RxTlpAsynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDE
                 NULL
             );
             ctx->async2.fOverlappedInitialized = FALSE;
+            ctx->async2.fReadPending = FALSE;
             ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
             if(fCancelled && !ctx->dev.pfnFT_InitializeOverlapped(ctx->dev.hFTDI, &ctx->async2.oOverlapped)) {
                 ctx->async2.fOverlappedInitialized = TRUE;
+                ctx->async2.fReadPending = FALSE;
             } else if(ctx->fFT601) {
                 fTransportError = TRUE;
                 DeviceFPGA_FTDI_RxRecover(ctxLC, ctx, FT_OTHER_ERROR, FALSE);

--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -1290,6 +1290,7 @@ VOID DeviceFPGA_Close(_Inout_ PLC_CONTEXT ctxLC)
 {
     PDEVICE_CONTEXT_FPGA ctx = (PDEVICE_CONTEXT_FPGA)ctxLC->hDevice;
     FPGA_READ_COUNTERS ReadCounters;
+    BOOL fOverlappedReleased = FALSE;
     if(!ctx) { return; }
     if(ctx->cTransportTimeout || ctx->cTransportRecoverySuccess || ctx->cTransportRecoveryFailure) {
         lcprintfv(ctxLC,
@@ -1328,17 +1329,25 @@ VOID DeviceFPGA_Close(_Inout_ PLC_CONTEXT ctxLC)
             ctx->dev.pfnFT_ReleaseOverlapped,
             NULL,
             NULL,
-            NULL
+            NULL,
+            &fOverlappedReleased
         );
-        ctx->async2.fOverlappedInitialized = FALSE;
-        ctx->async2.fReadPending = FALSE;
-        ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+        if(fOverlappedReleased) {
+            ctx->async2.fOverlappedInitialized = FALSE;
+            ctx->async2.fReadPending = FALSE;
+            ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+        }
     }
 #ifdef WIN32
     __try {
 #endif /* WIN32 */
         if(ctx->dev.hFTDI) {
             ctx->dev.pfnFT_Close(ctx->dev.hFTDI);
+            if(!fOverlappedReleased) {
+                ctx->async2.fOverlappedInitialized = FALSE;
+                ctx->async2.fReadPending = FALSE;
+                ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+            }
             ctx->dev.hFTDI = NULL;
         }
         if(ctx->dev.fInitialized) {
@@ -2286,6 +2295,7 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
 {
     PDEVICE_FPGA_FTDI_RECOVERY_CONTEXT pRecovery = (PDEVICE_FPGA_FTDI_RECOVERY_CONTEXT)pvContext;
     BOOL fResult = TRUE;
+    BOOL fOverlappedReleased = FALSE;
     DWORD status;
     PDEVICE_CONTEXT_FPGA ctx = pRecovery->ctx;
     if(!ctx->dev.hFTDI) { return TRUE; }
@@ -2299,10 +2309,13 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
             ctx->dev.pfnFT_ReleaseOverlapped,
             NULL,
             NULL,
-            NULL);
-        ctx->async2.fOverlappedInitialized = FALSE;
-        ctx->async2.fReadPending = FALSE;
-        ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+            NULL,
+            &fOverlappedReleased);
+        if(fOverlappedReleased) {
+            ctx->async2.fOverlappedInitialized = FALSE;
+            ctx->async2.fReadPending = FALSE;
+            ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+        }
     } else if(ctx->async2.fReadPending) {
         fResult = ctx->dev.pfnFT_AbortPipe &&
             (ctx->dev.pfnFT_AbortPipe(ctx->dev.hFTDI, 0x82) == DEVICE_FPGA_SESSION_FT_OK);
@@ -2312,6 +2325,12 @@ static BOOL DeviceFPGA_FTDI_RecoveryQuiesce(_Inout_ PVOID pvContext)
         return FALSE;
     }
     ctx->dev.hFTDI = NULL;
+    if(!fOverlappedReleased &&
+       (ctx->async2.fOverlappedInitialized || ctx->async2.fReadPending)) {
+        ctx->async2.fOverlappedInitialized = FALSE;
+        ctx->async2.fReadPending = FALSE;
+        ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+    }
     return fResult;
 }
 
@@ -4126,7 +4145,7 @@ BOOL DeviceFPGA_SynchOldAsync_RxTlpAsynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDE
     PBYTE pbBuffer = NULL;
     BOOL fAsyncInProgress = FALSE;
     BOOL fAsync = DeviceFPGA_FTDI_CanReadPipeBounded(ctx) || (cbBytesToRead > 0x4000);
-    BOOL fTimedOut, fCancelled, fTransportError = FALSE;
+    BOOL fTimedOut, fCancelled, fOverlappedReleased, fTransportError = FALSE;
     DEVICE_FPGA_SESSION_WAIT_RESULT WaitResult;
     PTLP_CALLBACK_BUF_MRd_SCATTER prxbuf = ctx->pMRdBufferX;
     if(!ctx->fTransportUsable) { return TRUE; }
@@ -4224,11 +4243,14 @@ BOOL DeviceFPGA_SynchOldAsync_RxTlpAsynchronous(_In_ PLC_CONTEXT ctxLC, _In_ PDE
                 ctx->dev.pfnFT_ReleaseOverlapped,
                 NULL,
                 NULL,
-                NULL
+                NULL,
+                &fOverlappedReleased
             );
-            ctx->async2.fOverlappedInitialized = FALSE;
-            ctx->async2.fReadPending = FALSE;
-            ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+            if(fOverlappedReleased) {
+                ctx->async2.fOverlappedInitialized = FALSE;
+                ctx->async2.fReadPending = FALSE;
+                ZeroMemory(&ctx->async2.oOverlapped, sizeof(ctx->async2.oOverlapped));
+            }
             if(fCancelled && !ctx->dev.pfnFT_InitializeOverlapped(ctx->dev.hFTDI, &ctx->async2.oOverlapped)) {
                 ctx->async2.fOverlappedInitialized = TRUE;
                 ctx->async2.fReadPending = FALSE;

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -170,6 +170,7 @@ DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_Session_ReadPipeBounded(
     _In_ LPOVERLAPPED pOverlapped,
     _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
     _In_ PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT pfnGetOverlappedResult,
+    _Out_ PBOOL pfReadPending,
     _In_ BOOL fUseEventWait,
     _In_ DWORD dwTimeoutMs,
     _In_ DWORD dwPollMs,
@@ -183,18 +184,21 @@ DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_Session_ReadPipeBounded(
         (ULONG)-1,
         0
     };
+    if(pfReadPending) { *pfReadPending = FALSE; }
     if(!hFTDI || !pbBuffer || !cbBuffer || !pOverlapped || !pfnReadPipe ||
-       !pfnGetOverlappedResult || !dwTimeoutMs || !dwPollMs ||
+       !pfnGetOverlappedResult || !pfReadPending || !dwTimeoutMs || !dwPollMs ||
        !pfnTick || !pfnSleep) {
         return Result;
     }
-    Result.status = pfnReadPipe(
+    Result.status = DeviceFPGA_Session_StartOverlappedRead(
         hFTDI,
         ucPipeID,
         pbBuffer,
         cbBuffer,
         &Result.cbTransferred,
-        pOverlapped);
+        pOverlapped,
+        pfnReadPipe,
+        pfReadPending);
     if(Result.status == DEVICE_FPGA_SESSION_FT_OK) {
         Result.outcome = DEVICE_FPGA_SESSION_WAIT_COMPLETED;
         return Result;
@@ -203,7 +207,7 @@ DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_Session_ReadPipeBounded(
     if(Result.status != DEVICE_FPGA_SESSION_FT_IO_PENDING) {
         return Result;
     }
-    return DeviceFPGA_Session_WaitOverlapped(
+    Result = DeviceFPGA_Session_WaitOverlapped(
         hFTDI,
         pOverlapped,
         pfnGetOverlappedResult,
@@ -213,6 +217,10 @@ DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_Session_ReadPipeBounded(
         pvTimingContext,
         pfnTick,
         pfnSleep);
+    if(Result.outcome == DEVICE_FPGA_SESSION_WAIT_COMPLETED) {
+        *pfReadPending = FALSE;
+    }
+    return Result;
 }
 
 ULONG DeviceFPGA_Session_StartOverlappedRead(

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -215,6 +215,34 @@ DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_Session_ReadPipeBounded(
         pfnSleep);
 }
 
+ULONG DeviceFPGA_Session_StartOverlappedRead(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _Out_writes_(cbBuffer) PUCHAR pbBuffer,
+    _In_ ULONG cbBuffer,
+    _Out_ PULONG pcbTransferred,
+    _In_ LPOVERLAPPED pOverlapped,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _Out_ PBOOL pfReadPending
+)
+{
+    ULONG status;
+    if(pfReadPending) { *pfReadPending = FALSE; }
+    if(!hFTDI || !pbBuffer || !cbBuffer || !pcbTransferred ||
+       !pOverlapped || !pfnReadPipe || !pfReadPending) {
+        return (ULONG)-1;
+    }
+    status = pfnReadPipe(
+        hFTDI,
+        ucPipeID,
+        pbBuffer,
+        cbBuffer,
+        pcbTransferred,
+        pOverlapped);
+    *pfReadPending = status == DEVICE_FPGA_SESSION_FT_IO_PENDING;
+    return status;
+}
+
 DEVICE_FPGA_SESSION_RECOVERY_STAGE DeviceFPGA_Session_Recover(
     _Inout_ PVOID pvContext,
     _In_ PDEVICE_FPGA_SESSION_RECOVERY_OPS pOps
@@ -527,4 +555,34 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
     fResult &= pfnReleaseOverlapped(hFTDI, pOverlapped) ==
         DEVICE_FPGA_SESSION_FT_OK;
     return fResult;
+}
+
+_Success_(return)
+BOOL DeviceFPGA_Session_TeardownOverlapped(
+    _In_ HANDLE hFTDI,
+    _In_ LPOVERLAPPED pOverlapped,
+    _In_ BOOL fReadPending,
+    _In_ PFN_DEVICE_FPGA_SESSION_ABORT_PIPE pfnAbortPipe,
+    _In_ PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT pfnGetOverlappedResult,
+    _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
+)
+{
+    if(!hFTDI || !pOverlapped) { return TRUE; }
+    if(!fReadPending) {
+        return pfnReleaseOverlapped &&
+            (pfnReleaseOverlapped(hFTDI, pOverlapped) ==
+             DEVICE_FPGA_SESSION_FT_OK);
+    }
+    return DeviceFPGA_Session_CloseOverlapped(
+        hFTDI,
+        pOverlapped,
+        pfnAbortPipe,
+        pfnGetOverlappedResult,
+        pfnReleaseOverlapped,
+        pvTimingContext,
+        pfnTick,
+        pfnSleep);
 }

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -556,6 +556,7 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
             DEVICE_FPGA_SESSION_FT_OK;
     }
     if(ftStatus != DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE) {
+        // Leave uncertain active state handle-owned; callers close or recover the handle before reuse.
         return FALSE;
     }
     // RX only: some callers don't hold the TX fast-write lock, and aborting TX here could cancel an in-flight write on that path.

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -530,7 +530,7 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
 )
 {
     BOOL fResult = TRUE;
-    ULONG ftStatus;
+    ULONG ftStatus, cbTransferred = 0;
     DEVICE_FPGA_SESSION_WAIT_RESULT WaitResult;
     if(!hFTDI || !pOverlapped) { return TRUE; }
     if(!pfnAbortPipe || !pfnGetOverlappedResult || !pfnReleaseOverlapped) {
@@ -538,6 +538,18 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
     }
     if(!pfnTick) { pfnTick = DeviceFPGA_Session_DefaultTick; }
     if(!pfnSleep) { pfnSleep = DeviceFPGA_Session_DefaultSleep; }
+    ftStatus = pfnGetOverlappedResult(
+        hFTDI,
+        pOverlapped,
+        &cbTransferred,
+        FALSE);
+    if(ftStatus == DEVICE_FPGA_SESSION_FT_OK) {
+        return pfnReleaseOverlapped(hFTDI, pOverlapped) ==
+            DEVICE_FPGA_SESSION_FT_OK;
+    }
+    if(ftStatus != DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE) {
+        return FALSE;
+    }
     // RX only: some callers don't hold the TX fast-write lock, and aborting TX here could cancel an in-flight write on that path.
     ftStatus = pfnAbortPipe(hFTDI, 0x82);
     fResult &= ftStatus == DEVICE_FPGA_SESSION_FT_OK;
@@ -551,7 +563,9 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
         pvTimingContext,
         pfnTick,
         pfnSleep);
-    fResult &= WaitResult.outcome == DEVICE_FPGA_SESSION_WAIT_COMPLETED;
+    if(WaitResult.outcome != DEVICE_FPGA_SESSION_WAIT_COMPLETED) {
+        return FALSE;
+    }
     fResult &= pfnReleaseOverlapped(hFTDI, pOverlapped) ==
         DEVICE_FPGA_SESSION_FT_OK;
     return fResult;

--- a/leechcore/device_fpga_session.c
+++ b/leechcore/device_fpga_session.c
@@ -534,13 +534,19 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,
     _In_opt_ PVOID pvTimingContext,
     _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick,
-    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep,
+    _Out_ PBOOL pfOverlappedReleased
 )
 {
     BOOL fResult = TRUE;
     ULONG ftStatus, cbTransferred = 0;
     DEVICE_FPGA_SESSION_WAIT_RESULT WaitResult;
-    if(!hFTDI || !pOverlapped) { return TRUE; }
+    if(!pfOverlappedReleased) { return FALSE; }
+    *pfOverlappedReleased = FALSE;
+    if(!hFTDI || !pOverlapped) {
+        *pfOverlappedReleased = TRUE;
+        return TRUE;
+    }
     if(!pfnAbortPipe || !pfnGetOverlappedResult || !pfnReleaseOverlapped) {
         return FALSE;
     }
@@ -552,13 +558,12 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
         &cbTransferred,
         FALSE);
     if(ftStatus == DEVICE_FPGA_SESSION_FT_OK) {
-        return pfnReleaseOverlapped(hFTDI, pOverlapped) ==
+        *pfOverlappedReleased = pfnReleaseOverlapped(hFTDI, pOverlapped) ==
             DEVICE_FPGA_SESSION_FT_OK;
+        return *pfOverlappedReleased;
     }
-    if(ftStatus != DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE) {
-        // Leave uncertain active state handle-owned; callers close or recover the handle before reuse.
-        return FALSE;
-    }
+    // FTDI recommends aborting the pipe after any non-success query status.
+    // This also preserves the upstream recovery attempt for unexpected errors.
     // RX only: some callers don't hold the TX fast-write lock, and aborting TX here could cancel an in-flight write on that path.
     ftStatus = pfnAbortPipe(hFTDI, 0x82);
     fResult &= ftStatus == DEVICE_FPGA_SESSION_FT_OK;
@@ -575,9 +580,9 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
     if(WaitResult.outcome != DEVICE_FPGA_SESSION_WAIT_COMPLETED) {
         return FALSE;
     }
-    fResult &= pfnReleaseOverlapped(hFTDI, pOverlapped) ==
+    *pfOverlappedReleased = pfnReleaseOverlapped(hFTDI, pOverlapped) ==
         DEVICE_FPGA_SESSION_FT_OK;
-    return fResult;
+    return fResult && *pfOverlappedReleased;
 }
 
 _Success_(return)
@@ -590,14 +595,21 @@ BOOL DeviceFPGA_Session_TeardownOverlapped(
     _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,
     _In_opt_ PVOID pvTimingContext,
     _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick,
-    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep,
+    _Out_ PBOOL pfOverlappedReleased
 )
 {
-    if(!hFTDI || !pOverlapped) { return TRUE; }
+    if(!pfOverlappedReleased) { return FALSE; }
+    *pfOverlappedReleased = FALSE;
+    if(!hFTDI || !pOverlapped) {
+        *pfOverlappedReleased = TRUE;
+        return TRUE;
+    }
     if(!fReadPending) {
-        return pfnReleaseOverlapped &&
+        *pfOverlappedReleased = pfnReleaseOverlapped &&
             (pfnReleaseOverlapped(hFTDI, pOverlapped) ==
              DEVICE_FPGA_SESSION_FT_OK);
+        return *pfOverlappedReleased;
     }
     return DeviceFPGA_Session_CloseOverlapped(
         hFTDI,
@@ -607,5 +619,6 @@ BOOL DeviceFPGA_Session_TeardownOverlapped(
         pfnReleaseOverlapped,
         pvTimingContext,
         pfnTick,
-        pfnSleep);
+        pfnSleep,
+        pfOverlappedReleased);
 }

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -289,6 +289,8 @@ BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
 );
 
 _Success_(return)
+// Query completion before cancelling. Release only after completion is
+// observed, either before cancellation or after a bounded cancellation wait.
 BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_ HANDLE hFTDI,
     _In_ LPOVERLAPPED pOverlapped,
@@ -300,8 +302,8 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
 );
 
-// Release an initialized idle OVERLAPPED object directly. If a read is
-// pending, cancel and wait for it before releasing the object.
+// Release an initialized idle OVERLAPPED object directly. If a read was
+// submitted, query it before deciding whether cancellation is required.
 _Success_(return)
 BOOL DeviceFPGA_Session_TeardownOverlapped(
     _In_ HANDLE hFTDI,

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -223,6 +223,7 @@ DEVICE_FPGA_SESSION_WAIT_RESULT DeviceFPGA_Session_ReadPipeBounded(
     _In_ LPOVERLAPPED pOverlapped,
     _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
     _In_ PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT pfnGetOverlappedResult,
+    _Out_ PBOOL pfReadPending,
     _In_ BOOL fUseEventWait,
     _In_ DWORD dwTimeoutMs,
     _In_ DWORD dwPollMs,

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -151,6 +151,17 @@ typedef struct tdDEVICE_FPGA_SESSION_WAIT_RESULT {
     ULONG cbTransferred;
 } DEVICE_FPGA_SESSION_WAIT_RESULT, *PDEVICE_FPGA_SESSION_WAIT_RESULT;
 
+ULONG DeviceFPGA_Session_StartOverlappedRead(
+    _In_ HANDLE hFTDI,
+    _In_ UCHAR ucPipeID,
+    _Out_writes_(cbBuffer) PUCHAR pbBuffer,
+    _In_ ULONG cbBuffer,
+    _Out_ PULONG pcbTransferred,
+    _In_ LPOVERLAPPED pOverlapped,
+    _In_ PFN_DEVICE_FPGA_SESSION_READ_PIPE pfnReadPipe,
+    _Out_ PBOOL pfReadPending
+);
+
 typedef enum tdDEVICE_FPGA_SESSION_RECOVERY_STAGE {
     DEVICE_FPGA_SESSION_RECOVERY_READY = 0,
     DEVICE_FPGA_SESSION_RECOVERY_QUIESCE_FAILED,
@@ -281,6 +292,21 @@ _Success_(return)
 BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_ HANDLE hFTDI,
     _In_ LPOVERLAPPED pOverlapped,
+    _In_ PFN_DEVICE_FPGA_SESSION_ABORT_PIPE pfnAbortPipe,
+    _In_ PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT pfnGetOverlappedResult,
+    _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,
+    _In_opt_ PVOID pvTimingContext,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick,
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
+);
+
+// Release an initialized idle OVERLAPPED object directly. If a read is
+// pending, cancel and wait for it before releasing the object.
+_Success_(return)
+BOOL DeviceFPGA_Session_TeardownOverlapped(
+    _In_ HANDLE hFTDI,
+    _In_ LPOVERLAPPED pOverlapped,
+    _In_ BOOL fReadPending,
     _In_ PFN_DEVICE_FPGA_SESSION_ABORT_PIPE pfnAbortPipe,
     _In_ PFN_DEVICE_FPGA_SESSION_GET_OVERLAPPED_RESULT pfnGetOverlappedResult,
     _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -289,9 +289,9 @@ BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
     _In_ PFN_DEVICE_FPGA_SESSION_SET_PIPE_TIMEOUT pfnSetPipeTimeout
 );
 
-_Success_(return)
 // Query completion before cancelling. Release only after completion is
 // observed, either before cancellation or after a bounded cancellation wait.
+_Success_(return)
 BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_ HANDLE hFTDI,
     _In_ LPOVERLAPPED pOverlapped,

--- a/leechcore/device_fpga_session.h
+++ b/leechcore/device_fpga_session.h
@@ -291,6 +291,8 @@ BOOL DeviceFPGA_Session_ConfigurePipeTimeouts(
 
 // Query completion before cancelling. Release only after completion is
 // observed, either before cancellation or after a bounded cancellation wait.
+// pfOverlappedReleased distinguishes cleanup success from resource ownership;
+// FALSE means the initialized object must remain handle-owned until close.
 _Success_(return)
 BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_ HANDLE hFTDI,
@@ -300,7 +302,8 @@ BOOL DeviceFPGA_Session_CloseOverlapped(
     _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,
     _In_opt_ PVOID pvTimingContext,
     _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick,
-    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep,
+    _Out_ PBOOL pfOverlappedReleased
 );
 
 // Release an initialized idle OVERLAPPED object directly. If a read was
@@ -315,7 +318,8 @@ BOOL DeviceFPGA_Session_TeardownOverlapped(
     _In_ PFN_DEVICE_FPGA_SESSION_RELEASE_OVERLAPPED pfnReleaseOverlapped,
     _In_opt_ PVOID pvTimingContext,
     _In_opt_ PFN_DEVICE_FPGA_SESSION_TICK pfnTick,
-    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep
+    _In_opt_ PFN_DEVICE_FPGA_SESSION_SLEEP pfnSleep,
+    _Out_ PBOOL pfOverlappedReleased
 );
 
 #endif /* __DEVICE_FPGA_SESSION_H__ */

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -992,6 +992,7 @@ typedef struct tdCLOSE_SCRIPT {
     QWORD qwNow;
     ULONG ulRxAbortStatus;
     ULONG ulTxAbortStatus;
+    ULONG ulPreAbortGetStatus;
     ULONG ulGetStatus;
     ULONG ulReleaseStatus;
     BOOL fRxAborted;
@@ -1024,15 +1025,18 @@ static ULONG WINAPI ScriptedGetOverlappedResult(
 )
 {
     PCLOSE_SCRIPT pScript = (PCLOSE_SCRIPT)hFTDI;
+    BOOL fBeforeAbort = !pScript->fRxAborted;
     UNREFERENCED_PARAMETER(pOverlapped);
     *pulLengthTransferred = 0;
     pScript->cGetCalls++;
-    pScript->fWaitedBeforeAbort = !pScript->fRxAborted;
+    pScript->fWaitedBeforeAbort |= fBeforeAbort;
     pScript->fSawWaitArgument |= fWait;
     if(pScript->cEvents < sizeof(pScript->pbEvents)) {
         pScript->pbEvents[pScript->cEvents++] = EVENT_GET_OVERLAPPED;
     }
-    return pScript->fWaitedBeforeAbort ? 1 : pScript->ulGetStatus;
+    return fBeforeAbort ?
+        pScript->ulPreAbortGetStatus :
+        pScript->ulGetStatus;
 }
 
 static ULONG WINAPI ScriptedReleaseOverlapped(
@@ -1089,7 +1093,10 @@ static VOID TestTrackedCloseCancelsPendingReadBeforeRelease(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
-    BYTE pbExpected[] = { 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE };
+    BYTE pbExpected[] = {
+        EVENT_GET_OVERLAPPED, 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE
+    };
+    Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     ASSERT_TRUE(DeviceFPGA_Session_TeardownOverlapped(
         &Script,
         &Overlapped,
@@ -1102,7 +1109,31 @@ static VOID TestTrackedCloseCancelsPendingReadBeforeRelease(VOID)
         ScriptedCloseSleep));
     ASSERT_TRUE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
-    ASSERT_FALSE(Script.fWaitedBeforeAbort);
+    ASSERT_TRUE(Script.fWaitedBeforeAbort);
+    ASSERT_EQ(Script.cEvents, sizeof(pbExpected));
+    ASSERT_BYTES(Script.pbEvents, pbExpected, sizeof(pbExpected));
+}
+
+static VOID TestTrackedCloseReleasesCompletedReadWithoutCancelling(VOID)
+{
+    CLOSE_SCRIPT Script = { 0 };
+    OVERLAPPED Overlapped = { 0 };
+    BYTE pbExpected[] = { EVENT_GET_OVERLAPPED, EVENT_RELEASE };
+    ASSERT_TRUE(DeviceFPGA_Session_TeardownOverlapped(
+        &Script,
+        &Overlapped,
+        TRUE,
+        ScriptedAbortPipe,
+        ScriptedGetOverlappedResult,
+        ScriptedReleaseOverlapped,
+        &Script,
+        ScriptedCloseTick,
+        ScriptedCloseSleep));
+    ASSERT_FALSE(Script.fRxAborted);
+    ASSERT_FALSE(Script.fTxAborted);
+    ASSERT_TRUE(Script.fWaitedBeforeAbort);
+    ASSERT_EQ(Script.cGetCalls, 1);
+    ASSERT_EQ(Script.cReleaseCalls, 1);
     ASSERT_EQ(Script.cEvents, sizeof(pbExpected));
     ASSERT_BYTES(Script.pbEvents, pbExpected, sizeof(pbExpected));
 }
@@ -1111,12 +1142,16 @@ static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
-    BYTE pbExpected[] = { 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE };
+    BYTE pbExpected[] = {
+        EVENT_GET_OVERLAPPED, 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE
+    };
 
     TestOverlappedReadSubmissionTracksOnlyPendingStatus();
     TestTrackedCloseReleasesIdleReadWithoutCancelling();
+    TestTrackedCloseReleasesCompletedReadWithoutCancelling();
     TestTrackedCloseCancelsPendingReadBeforeRelease();
 
+    Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     ASSERT_TRUE(DeviceFPGA_Session_CloseOverlapped(
         &Script,
         &Overlapped,
@@ -1126,7 +1161,7 @@ static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
         &Script,
         ScriptedCloseTick,
         ScriptedCloseSleep));
-    ASSERT_FALSE(Script.fWaitedBeforeAbort);
+    ASSERT_TRUE(Script.fWaitedBeforeAbort);
     ASSERT_FALSE(Script.fSawWaitArgument);
     ASSERT_TRUE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
@@ -1134,10 +1169,11 @@ static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
     ASSERT_BYTES(Script.pbEvents, pbExpected, sizeof(pbExpected));
 }
 
-static VOID TestClosePendingForeverIsBoundedAndStillReleases(VOID)
+static VOID TestClosePendingForeverIsBoundedAndDoesNotRelease(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     Script.ulGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     ASSERT_FALSE(DeviceFPGA_Session_CloseOverlapped(
         &Script,
@@ -1150,14 +1186,15 @@ static VOID TestClosePendingForeverIsBoundedAndStillReleases(VOID)
         ScriptedCloseSleep));
     ASSERT_FALSE(Script.fSawWaitArgument);
     ASSERT_EQ(Script.qwNow, DEVICE_FPGA_SESSION_CANCEL_TIMEOUT_MS);
-    ASSERT_EQ(Script.cGetCalls, DEVICE_FPGA_SESSION_CANCEL_TIMEOUT_MS + 1);
-    ASSERT_EQ(Script.cReleaseCalls, 1);
+    ASSERT_EQ(Script.cGetCalls, DEVICE_FPGA_SESSION_CANCEL_TIMEOUT_MS + 2);
+    ASSERT_EQ(Script.cReleaseCalls, 0);
 }
 
 static VOID TestCloseReportsAbortErrorAfterAttemptingCleanup(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     Script.ulRxAbortStatus = 1;
     ASSERT_FALSE(DeviceFPGA_Session_CloseOverlapped(
         &Script,
@@ -1170,7 +1207,7 @@ static VOID TestCloseReportsAbortErrorAfterAttemptingCleanup(VOID)
         ScriptedCloseSleep));
     ASSERT_TRUE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
-    ASSERT_EQ(Script.cGetCalls, 1);
+    ASSERT_EQ(Script.cGetCalls, 2);
     ASSERT_EQ(Script.cReleaseCalls, 1);
 }
 
@@ -1650,7 +1687,7 @@ int main(void)
     RUN_TEST(TestWaitPendingForeverTimesOutAtDeadline);
     RUN_TEST(TestWaitReturnsDriverErrorWithoutRetry);
     RUN_TEST(TestOverlappedReadLifecycleAndCloseOrdering);
-    RUN_TEST(TestClosePendingForeverIsBoundedAndStillReleases);
+    RUN_TEST(TestClosePendingForeverIsBoundedAndDoesNotRelease);
     RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
     RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);
     RUN_TEST(TestConfigurePipeTimeoutsReportsEitherFailure);

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -1170,10 +1170,10 @@ static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
         EVENT_GET_OVERLAPPED, 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE
     };
 
-    TestOverlappedReadSubmissionTracksOnlyPendingStatus();
-    TestTrackedCloseReleasesIdleReadWithoutCancelling();
-    TestTrackedCloseReleasesCompletedReadWithoutCancelling();
-    TestTrackedCloseCancelsPendingReadBeforeRelease();
+    RUN_TEST(TestOverlappedReadSubmissionTracksOnlyPendingStatus);
+    RUN_TEST(TestTrackedCloseReleasesIdleReadWithoutCancelling);
+    RUN_TEST(TestTrackedCloseReleasesCompletedReadWithoutCancelling);
+    RUN_TEST(TestTrackedCloseCancelsPendingReadBeforeRelease);
 
     Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     ASSERT_TRUE(DeviceFPGA_Session_CloseOverlapped(

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -4,6 +4,13 @@
 #include "../leechcore/device_fpga_session.h"
 
 static int g_cFailures = 0;
+static int g_cTests = 0;
+
+#define RUN_TEST(test) \
+    do { \
+        (test)(); \
+        g_cTests++; \
+    } while(0)
 
 #define ASSERT_TRUE(value) \
     do { \
@@ -1516,58 +1523,58 @@ static VOID TestDrainRejectsInvalidPolicy(VOID)
 
 int main(void)
 {
-    TestCompleteAlignedReply();
-    TestCompleteUnalignedReply();
-    TestCompleteZeroValuedReply();
-    TestEmptyReplyFailsAndClearsOutput();
-    TestPartialReplyFailsAndClearsOutput();
-    TestWrongSourceReplyFailsAndClearsOutput();
-    TestV4IdentityRetriesAndPublishesCompleteReply();
-    TestV4IdentityFailureIsBoundedAndDoesNotPublish();
-    TestV4IdentityAcceptsExplicitZeroFpgaId();
-    TestV4IdentityRejectsLegacyMajorWithoutPublishing();
-    TestV3IdentityRequiresEveryIdentityCommand();
-    TestV3IdentityPublishesCompleteReply();
-    TestV3IdentityAcceptsExplicitZeroFpgaId();
-    TestTlpFrameIgnoresContinuationUntilFirst();
-    TestTlpFrameCompletesAfterExplicitFirst();
-    TestTlpFrameRestartsAtNewFirst();
-    TestTlpFrameRejectsShortAndOversizePackets();
-    TestTlpFrameAcceptsLegacyStreamWithoutFirst();
-    TestBoundedReadReturnsImmediateCompletion();
-    TestBoundedReadWaitsForPendingCompletion();
-    TestBoundedReadPendingForeverTimesOut();
-    TestBoundedReadReturnsSubmissionErrorWithoutPolling();
-    TestBoundedReadRejectsInvalidArguments();
-    TestWaitUsesEventWithoutPolling();
-    TestWaitFallsBackToPollingAfterEarlyEvent();
-    TestWaitCanBypassSignaledEventForPolling();
-    TestWaitEventTimeoutDoesNotPoll();
-    TestWaitCompletesWithoutBlockingDriverCall();
-    TestWaitPendingForeverTimesOutAtDeadline();
-    TestWaitReturnsDriverErrorWithoutRetry();
-    TestCloseCancelsReadPipeBeforeWaiting();
-    TestClosePendingForeverIsBoundedAndStillReleases();
-    TestCloseReportsAbortErrorAfterAttemptingCleanup();
-    TestConfigurePipeTimeoutsConfiguresBothDirections();
-    TestConfigurePipeTimeoutsReportsEitherFailure();
-    TestRecoveryCoordinatorExecutesOneOrderedAttempt();
-    TestRecoveryCoordinatorStopsAtEachFailedStage();
-    TestRecoveryCoordinatorRejectsIncompleteOpsBeforeStarting();
-    TestFillerClassificationRequiresCompleteFillerWords();
-    TestDrainRequiresSustainedQuiescence();
-    TestDrainResetsQuietWindowAfterTraffic();
-    TestDrainReportsReadErrorWithoutRetry();
-    TestDrainRejectsOversizedRead();
-    TestDrainEnforcesNonFillerByteLimit();
-    TestDrainEnforcesOverallDeadline();
-    TestDrainDeadlineWinsAfterSlowRead();
-    TestDrainPassesRemainingDeadlineToReads();
-    TestDrainRejectsInvalidPolicy();
+    RUN_TEST(TestCompleteAlignedReply);
+    RUN_TEST(TestCompleteUnalignedReply);
+    RUN_TEST(TestCompleteZeroValuedReply);
+    RUN_TEST(TestEmptyReplyFailsAndClearsOutput);
+    RUN_TEST(TestPartialReplyFailsAndClearsOutput);
+    RUN_TEST(TestWrongSourceReplyFailsAndClearsOutput);
+    RUN_TEST(TestV4IdentityRetriesAndPublishesCompleteReply);
+    RUN_TEST(TestV4IdentityFailureIsBoundedAndDoesNotPublish);
+    RUN_TEST(TestV4IdentityAcceptsExplicitZeroFpgaId);
+    RUN_TEST(TestV4IdentityRejectsLegacyMajorWithoutPublishing);
+    RUN_TEST(TestV3IdentityRequiresEveryIdentityCommand);
+    RUN_TEST(TestV3IdentityPublishesCompleteReply);
+    RUN_TEST(TestV3IdentityAcceptsExplicitZeroFpgaId);
+    RUN_TEST(TestTlpFrameIgnoresContinuationUntilFirst);
+    RUN_TEST(TestTlpFrameCompletesAfterExplicitFirst);
+    RUN_TEST(TestTlpFrameRestartsAtNewFirst);
+    RUN_TEST(TestTlpFrameRejectsShortAndOversizePackets);
+    RUN_TEST(TestTlpFrameAcceptsLegacyStreamWithoutFirst);
+    RUN_TEST(TestBoundedReadReturnsImmediateCompletion);
+    RUN_TEST(TestBoundedReadWaitsForPendingCompletion);
+    RUN_TEST(TestBoundedReadPendingForeverTimesOut);
+    RUN_TEST(TestBoundedReadReturnsSubmissionErrorWithoutPolling);
+    RUN_TEST(TestBoundedReadRejectsInvalidArguments);
+    RUN_TEST(TestWaitUsesEventWithoutPolling);
+    RUN_TEST(TestWaitFallsBackToPollingAfterEarlyEvent);
+    RUN_TEST(TestWaitCanBypassSignaledEventForPolling);
+    RUN_TEST(TestWaitEventTimeoutDoesNotPoll);
+    RUN_TEST(TestWaitCompletesWithoutBlockingDriverCall);
+    RUN_TEST(TestWaitPendingForeverTimesOutAtDeadline);
+    RUN_TEST(TestWaitReturnsDriverErrorWithoutRetry);
+    RUN_TEST(TestCloseCancelsReadPipeBeforeWaiting);
+    RUN_TEST(TestClosePendingForeverIsBoundedAndStillReleases);
+    RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
+    RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);
+    RUN_TEST(TestConfigurePipeTimeoutsReportsEitherFailure);
+    RUN_TEST(TestRecoveryCoordinatorExecutesOneOrderedAttempt);
+    RUN_TEST(TestRecoveryCoordinatorStopsAtEachFailedStage);
+    RUN_TEST(TestRecoveryCoordinatorRejectsIncompleteOpsBeforeStarting);
+    RUN_TEST(TestFillerClassificationRequiresCompleteFillerWords);
+    RUN_TEST(TestDrainRequiresSustainedQuiescence);
+    RUN_TEST(TestDrainResetsQuietWindowAfterTraffic);
+    RUN_TEST(TestDrainReportsReadErrorWithoutRetry);
+    RUN_TEST(TestDrainRejectsOversizedRead);
+    RUN_TEST(TestDrainEnforcesNonFillerByteLimit);
+    RUN_TEST(TestDrainEnforcesOverallDeadline);
+    RUN_TEST(TestDrainDeadlineWinsAfterSlowRead);
+    RUN_TEST(TestDrainPassesRemainingDeadlineToReads);
+    RUN_TEST(TestDrainRejectsInvalidPolicy);
     if(g_cFailures) {
         printf("%d test assertion(s) failed.\n", g_cFailures);
         return 1;
     }
-    printf("PASS: 47 FPGA session protocol cases.\n");
+    printf("PASS: %d FPGA session protocol cases.\n", g_cTests);
     return 0;
 }

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -406,6 +406,51 @@ static ULONG WINAPI ScriptedReadPipe(
     return pScript->ulReadStatus;
 }
 
+static VOID TestOverlappedReadSubmissionTracksOnlyPendingStatus(VOID)
+{
+    READ_PIPE_SCRIPT Script = { 0 };
+    BYTE pbBuffer[64] = { 0 };
+    DWORD cbRead = 0;
+    OVERLAPPED Overlapped = { 0 };
+    BOOL fReadPending = FALSE;
+    Script.ulReadStatus = DEVICE_FPGA_SESSION_FT_IO_PENDING;
+    ASSERT_EQ(DeviceFPGA_Session_StartOverlappedRead(
+        &Script,
+        0x82,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        &Overlapped,
+        ScriptedReadPipe,
+        &fReadPending), DEVICE_FPGA_SESSION_FT_IO_PENDING);
+    ASSERT_TRUE(fReadPending);
+    Script.ulReadStatus = DEVICE_FPGA_SESSION_FT_OK;
+    fReadPending = TRUE;
+    ASSERT_EQ(DeviceFPGA_Session_StartOverlappedRead(
+        &Script,
+        0x82,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        &Overlapped,
+        ScriptedReadPipe,
+        &fReadPending), DEVICE_FPGA_SESSION_FT_OK);
+    ASSERT_FALSE(fReadPending);
+    Script.ulReadStatus = 0x20;
+    fReadPending = TRUE;
+    ASSERT_EQ(DeviceFPGA_Session_StartOverlappedRead(
+        &Script,
+        0x82,
+        pbBuffer,
+        sizeof(pbBuffer),
+        &cbRead,
+        &Overlapped,
+        ScriptedReadPipe,
+        &fReadPending), 0x20);
+    ASSERT_FALSE(fReadPending);
+    ASSERT_EQ(Script.cReadCalls, 3);
+}
+
 static ULONG WINAPI ScriptedWaitGetOverlappedResult(
     _In_ HANDLE hFTDI,
     _In_ LPOVERLAPPED pOverlapped,
@@ -1016,11 +1061,62 @@ static VOID ScriptedCloseSleep(_In_ PVOID pvContext, _In_ DWORD dwMilliseconds)
     pScript->qwNow += dwMilliseconds;
 }
 
-static VOID TestCloseCancelsReadPipeBeforeWaiting(VOID)
+static VOID TestTrackedCloseReleasesIdleReadWithoutCancelling(VOID)
+{
+    CLOSE_SCRIPT Script = { 0 };
+    OVERLAPPED Overlapped = { 0 };
+    BYTE pbExpected[] = { EVENT_RELEASE };
+    ASSERT_TRUE(DeviceFPGA_Session_TeardownOverlapped(
+        &Script,
+        &Overlapped,
+        FALSE,
+        ScriptedAbortPipe,
+        ScriptedGetOverlappedResult,
+        ScriptedReleaseOverlapped,
+        &Script,
+        ScriptedCloseTick,
+        ScriptedCloseSleep));
+    ASSERT_FALSE(Script.fRxAborted);
+    ASSERT_FALSE(Script.fTxAborted);
+    ASSERT_EQ(Script.cGetCalls, 0);
+    ASSERT_EQ(Script.cSleepCalls, 0);
+    ASSERT_EQ(Script.cReleaseCalls, 1);
+    ASSERT_EQ(Script.cEvents, sizeof(pbExpected));
+    ASSERT_BYTES(Script.pbEvents, pbExpected, sizeof(pbExpected));
+}
+
+static VOID TestTrackedCloseCancelsPendingReadBeforeRelease(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
     BYTE pbExpected[] = { 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE };
+    ASSERT_TRUE(DeviceFPGA_Session_TeardownOverlapped(
+        &Script,
+        &Overlapped,
+        TRUE,
+        ScriptedAbortPipe,
+        ScriptedGetOverlappedResult,
+        ScriptedReleaseOverlapped,
+        &Script,
+        ScriptedCloseTick,
+        ScriptedCloseSleep));
+    ASSERT_TRUE(Script.fRxAborted);
+    ASSERT_FALSE(Script.fTxAborted);
+    ASSERT_FALSE(Script.fWaitedBeforeAbort);
+    ASSERT_EQ(Script.cEvents, sizeof(pbExpected));
+    ASSERT_BYTES(Script.pbEvents, pbExpected, sizeof(pbExpected));
+}
+
+static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
+{
+    CLOSE_SCRIPT Script = { 0 };
+    OVERLAPPED Overlapped = { 0 };
+    BYTE pbExpected[] = { 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE };
+
+    TestOverlappedReadSubmissionTracksOnlyPendingStatus();
+    TestTrackedCloseReleasesIdleReadWithoutCancelling();
+    TestTrackedCloseCancelsPendingReadBeforeRelease();
+
     ASSERT_TRUE(DeviceFPGA_Session_CloseOverlapped(
         &Script,
         &Overlapped,
@@ -1553,7 +1649,7 @@ int main(void)
     RUN_TEST(TestWaitCompletesWithoutBlockingDriverCall);
     RUN_TEST(TestWaitPendingForeverTimesOutAtDeadline);
     RUN_TEST(TestWaitReturnsDriverErrorWithoutRetry);
-    RUN_TEST(TestCloseCancelsReadPipeBeforeWaiting);
+    RUN_TEST(TestOverlappedReadLifecycleAndCloseOrdering);
     RUN_TEST(TestClosePendingForeverIsBoundedAndStillReleases);
     RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
     RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -689,6 +689,7 @@ static VOID TestBoundedReadReturnsImmediateCompletion(VOID)
     OVERLAPPED Overlapped = { 0 };
     READ_PIPE_SCRIPT Script = { 0 };
     DEVICE_FPGA_SESSION_WAIT_RESULT Result;
+    BOOL fReadPending = TRUE;
     Script.cbImmediate = 0x2345;
     Result = DeviceFPGA_Session_ReadPipeBounded(
         &Script,
@@ -698,6 +699,7 @@ static VOID TestBoundedReadReturnsImmediateCompletion(VOID)
         &Overlapped,
         ScriptedReadPipe,
         ScriptedWaitGetOverlappedResult,
+        &fReadPending,
         TRUE,
         1000,
         1,
@@ -710,6 +712,7 @@ static VOID TestBoundedReadReturnsImmediateCompletion(VOID)
     ASSERT_EQ(Script.cReadCalls, 1);
     ASSERT_EQ(Script.Wait.cGetCalls, 0);
     ASSERT_EQ(Script.Wait.cSleepCalls, 0);
+    ASSERT_FALSE(fReadPending);
     ASSERT_EQ(Script.ucPipeID, 0x82);
     ASSERT_EQ(Script.cbBuffer, sizeof(pbBuffer));
     ASSERT_TRUE(Script.pbBuffer == pbBuffer);
@@ -722,6 +725,7 @@ static VOID TestBoundedReadWaitsForPendingCompletion(VOID)
     OVERLAPPED Overlapped = { 0 };
     READ_PIPE_SCRIPT Script = { 0 };
     DEVICE_FPGA_SESSION_WAIT_RESULT Result;
+    BOOL fReadPending = FALSE;
     HANDLE hSignalThread;
     WAIT_EVENT_SIGNAL Signal;
     Overlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
@@ -762,6 +766,7 @@ static VOID TestBoundedReadWaitsForPendingCompletion(VOID)
         &Overlapped,
         ScriptedReadPipe,
         ScriptedWaitGetOverlappedResult,
+        &fReadPending,
         TRUE,
         1000,
         1,
@@ -775,6 +780,7 @@ static VOID TestBoundedReadWaitsForPendingCompletion(VOID)
     ASSERT_EQ(Script.Wait.cGetCalls, 1);
     ASSERT_EQ(Script.Wait.cSleepCalls, 0);
     ASSERT_FALSE(Script.Wait.fWaitArgument);
+    ASSERT_FALSE(fReadPending);
     ASSERT_TRUE(Script.pOverlapped == &Overlapped);
     ASSERT_EQ(WaitForSingleObject(hSignalThread, 1000), WAIT_OBJECT_0);
     CloseHandle(hSignalThread);
@@ -788,6 +794,7 @@ static VOID TestBoundedReadPendingForeverTimesOut(VOID)
     OVERLAPPED Overlapped = { 0 };
     READ_PIPE_SCRIPT Script = { 0 };
     DEVICE_FPGA_SESSION_WAIT_RESULT Result;
+    BOOL fReadPending = FALSE;
     Overlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
     ASSERT_TRUE(Overlapped.hEvent != NULL);
     if(!Overlapped.hEvent) { return; }
@@ -801,6 +808,7 @@ static VOID TestBoundedReadPendingForeverTimesOut(VOID)
         &Overlapped,
         ScriptedReadPipe,
         ScriptedWaitGetOverlappedResult,
+        &fReadPending,
         TRUE,
         5,
         1,
@@ -815,6 +823,7 @@ static VOID TestBoundedReadPendingForeverTimesOut(VOID)
     ASSERT_EQ(Script.Wait.cGetCalls, 0);
     ASSERT_EQ(Script.Wait.cSleepCalls, 0);
     ASSERT_FALSE(Script.Wait.fWaitArgument);
+    ASSERT_TRUE(fReadPending);
     CloseHandle(Overlapped.hEvent);
 }
 
@@ -824,6 +833,7 @@ static VOID TestBoundedReadReturnsSubmissionErrorWithoutPolling(VOID)
     OVERLAPPED Overlapped = { 0 };
     READ_PIPE_SCRIPT Script = { 0 };
     DEVICE_FPGA_SESSION_WAIT_RESULT Result;
+    BOOL fReadPending = TRUE;
     Script.ulReadStatus = 0x20;
     Script.cbImmediate = 0x9999;
     Result = DeviceFPGA_Session_ReadPipeBounded(
@@ -834,6 +844,7 @@ static VOID TestBoundedReadReturnsSubmissionErrorWithoutPolling(VOID)
         &Overlapped,
         ScriptedReadPipe,
         ScriptedWaitGetOverlappedResult,
+        &fReadPending,
         TRUE,
         1000,
         1,
@@ -846,6 +857,7 @@ static VOID TestBoundedReadReturnsSubmissionErrorWithoutPolling(VOID)
     ASSERT_EQ(Script.cReadCalls, 1);
     ASSERT_EQ(Script.Wait.cGetCalls, 0);
     ASSERT_EQ(Script.Wait.cSleepCalls, 0);
+    ASSERT_FALSE(fReadPending);
 }
 
 static VOID TestBoundedReadRejectsInvalidArguments(VOID)
@@ -853,36 +865,48 @@ static VOID TestBoundedReadRejectsInvalidArguments(VOID)
     BYTE pbBuffer[0x100];
     OVERLAPPED Overlapped = { 0 };
     READ_PIPE_SCRIPT Script = { 0 };
-#define ASSERT_INVALID_BOUNDED_READ(handle, buffer, size, overlapped, read, get, tick, sleep) \
+#define ASSERT_INVALID_BOUNDED_READ(handle, buffer, size, overlapped, read, get, pending, tick, sleep) \
     ASSERT_EQ( \
         DeviceFPGA_Session_ReadPipeBounded( \
             (handle), 0x82, (buffer), (size), (overlapped), (read), (get), \
-            TRUE, 1000, 1, &Script.Wait, (tick), (sleep)).outcome, \
+            (pending), TRUE, 1000, 1, &Script.Wait, (tick), (sleep)).outcome, \
         DEVICE_FPGA_SESSION_WAIT_DRIVER_ERROR)
+    BOOL fReadPending = TRUE;
     ASSERT_INVALID_BOUNDED_READ(
         NULL, pbBuffer, sizeof(pbBuffer), &Overlapped, ScriptedReadPipe,
-        ScriptedWaitGetOverlappedResult, ScriptedWaitTick, ScriptedWaitSleep);
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, NULL, sizeof(pbBuffer), &Overlapped, ScriptedReadPipe,
-        ScriptedWaitGetOverlappedResult, ScriptedWaitTick, ScriptedWaitSleep);
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, pbBuffer, 0, &Overlapped, ScriptedReadPipe,
-        ScriptedWaitGetOverlappedResult, ScriptedWaitTick, ScriptedWaitSleep);
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, pbBuffer, sizeof(pbBuffer), NULL, ScriptedReadPipe,
-        ScriptedWaitGetOverlappedResult, ScriptedWaitTick, ScriptedWaitSleep);
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, pbBuffer, sizeof(pbBuffer), &Overlapped, NULL,
-        ScriptedWaitGetOverlappedResult, ScriptedWaitTick, ScriptedWaitSleep);
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, pbBuffer, sizeof(pbBuffer), &Overlapped, ScriptedReadPipe,
-        NULL, ScriptedWaitTick, ScriptedWaitSleep);
+        NULL, &fReadPending, ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, pbBuffer, sizeof(pbBuffer), &Overlapped, ScriptedReadPipe,
-        ScriptedWaitGetOverlappedResult, NULL, ScriptedWaitSleep);
+        ScriptedWaitGetOverlappedResult, NULL,
+        ScriptedWaitTick, ScriptedWaitSleep);
     ASSERT_INVALID_BOUNDED_READ(
         &Script, pbBuffer, sizeof(pbBuffer), &Overlapped, ScriptedReadPipe,
-        ScriptedWaitGetOverlappedResult, ScriptedWaitTick, NULL);
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        NULL, ScriptedWaitSleep);
+    ASSERT_INVALID_BOUNDED_READ(
+        &Script, pbBuffer, sizeof(pbBuffer), &Overlapped, ScriptedReadPipe,
+        ScriptedWaitGetOverlappedResult, &fReadPending,
+        ScriptedWaitTick, NULL);
 #undef ASSERT_INVALID_BOUNDED_READ
     ASSERT_EQ(Script.cReadCalls, 0);
     ASSERT_EQ(Script.Wait.cGetCalls, 0);

--- a/tests/device_fpga_session_test.c
+++ b/tests/device_fpga_session_test.c
@@ -1093,6 +1093,7 @@ static VOID TestTrackedCloseReleasesIdleReadWithoutCancelling(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = FALSE;
     BYTE pbExpected[] = { EVENT_RELEASE };
     ASSERT_TRUE(DeviceFPGA_Session_TeardownOverlapped(
         &Script,
@@ -1103,7 +1104,9 @@ static VOID TestTrackedCloseReleasesIdleReadWithoutCancelling(VOID)
         ScriptedReleaseOverlapped,
         &Script,
         ScriptedCloseTick,
-        ScriptedCloseSleep));
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_TRUE(fReleased);
     ASSERT_FALSE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
     ASSERT_EQ(Script.cGetCalls, 0);
@@ -1117,6 +1120,7 @@ static VOID TestTrackedCloseCancelsPendingReadBeforeRelease(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = FALSE;
     BYTE pbExpected[] = {
         EVENT_GET_OVERLAPPED, 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE
     };
@@ -1130,7 +1134,9 @@ static VOID TestTrackedCloseCancelsPendingReadBeforeRelease(VOID)
         ScriptedReleaseOverlapped,
         &Script,
         ScriptedCloseTick,
-        ScriptedCloseSleep));
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_TRUE(fReleased);
     ASSERT_TRUE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
     ASSERT_TRUE(Script.fWaitedBeforeAbort);
@@ -1142,6 +1148,7 @@ static VOID TestTrackedCloseReleasesCompletedReadWithoutCancelling(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = FALSE;
     BYTE pbExpected[] = { EVENT_GET_OVERLAPPED, EVENT_RELEASE };
     ASSERT_TRUE(DeviceFPGA_Session_TeardownOverlapped(
         &Script,
@@ -1152,7 +1159,9 @@ static VOID TestTrackedCloseReleasesCompletedReadWithoutCancelling(VOID)
         ScriptedReleaseOverlapped,
         &Script,
         ScriptedCloseTick,
-        ScriptedCloseSleep));
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_TRUE(fReleased);
     ASSERT_FALSE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
     ASSERT_TRUE(Script.fWaitedBeforeAbort);
@@ -1166,6 +1175,7 @@ static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = FALSE;
     BYTE pbExpected[] = {
         EVENT_GET_OVERLAPPED, 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE
     };
@@ -1184,7 +1194,9 @@ static VOID TestOverlappedReadLifecycleAndCloseOrdering(VOID)
         ScriptedReleaseOverlapped,
         &Script,
         ScriptedCloseTick,
-        ScriptedCloseSleep));
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_TRUE(fReleased);
     ASSERT_TRUE(Script.fWaitedBeforeAbort);
     ASSERT_FALSE(Script.fSawWaitArgument);
     ASSERT_TRUE(Script.fRxAborted);
@@ -1197,6 +1209,7 @@ static VOID TestClosePendingForeverIsBoundedAndDoesNotRelease(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = TRUE;
     Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     Script.ulGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     ASSERT_FALSE(DeviceFPGA_Session_CloseOverlapped(
@@ -1207,7 +1220,9 @@ static VOID TestClosePendingForeverIsBoundedAndDoesNotRelease(VOID)
         ScriptedReleaseOverlapped,
         &Script,
         ScriptedCloseTick,
-        ScriptedCloseSleep));
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_FALSE(fReleased);
     ASSERT_FALSE(Script.fSawWaitArgument);
     ASSERT_EQ(Script.qwNow, DEVICE_FPGA_SESSION_CANCEL_TIMEOUT_MS);
     ASSERT_EQ(Script.cGetCalls, DEVICE_FPGA_SESSION_CANCEL_TIMEOUT_MS + 2);
@@ -1218,6 +1233,7 @@ static VOID TestCloseReportsAbortErrorAfterAttemptingCleanup(VOID)
 {
     CLOSE_SCRIPT Script = { 0 };
     OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = FALSE;
     Script.ulPreAbortGetStatus = DEVICE_FPGA_SESSION_FT_IO_INCOMPLETE;
     Script.ulRxAbortStatus = 1;
     ASSERT_FALSE(DeviceFPGA_Session_CloseOverlapped(
@@ -1228,10 +1244,59 @@ static VOID TestCloseReportsAbortErrorAfterAttemptingCleanup(VOID)
         ScriptedReleaseOverlapped,
         &Script,
         ScriptedCloseTick,
-        ScriptedCloseSleep));
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_TRUE(fReleased);
     ASSERT_TRUE(Script.fRxAborted);
     ASSERT_FALSE(Script.fTxAborted);
     ASSERT_EQ(Script.cGetCalls, 2);
+    ASSERT_EQ(Script.cReleaseCalls, 1);
+}
+
+static VOID TestCloseUnexpectedQueryErrorStillAbortsAndReleases(VOID)
+{
+    CLOSE_SCRIPT Script = { 0 };
+    OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = FALSE;
+    BYTE pbExpected[] = {
+        EVENT_GET_OVERLAPPED, 0x82, EVENT_GET_OVERLAPPED, EVENT_RELEASE
+    };
+    Script.ulPreAbortGetStatus = 1;
+    ASSERT_TRUE(DeviceFPGA_Session_CloseOverlapped(
+        &Script,
+        &Overlapped,
+        ScriptedAbortPipe,
+        ScriptedGetOverlappedResult,
+        ScriptedReleaseOverlapped,
+        &Script,
+        ScriptedCloseTick,
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_TRUE(fReleased);
+    ASSERT_TRUE(Script.fRxAborted);
+    ASSERT_FALSE(Script.fTxAborted);
+    ASSERT_EQ(Script.cEvents, sizeof(pbExpected));
+    ASSERT_BYTES(Script.pbEvents, pbExpected, sizeof(pbExpected));
+}
+
+static VOID TestCloseReleaseFailureKeepsHandleOwnership(VOID)
+{
+    CLOSE_SCRIPT Script = { 0 };
+    OVERLAPPED Overlapped = { 0 };
+    BOOL fReleased = TRUE;
+    Script.ulReleaseStatus = 1;
+    ASSERT_FALSE(DeviceFPGA_Session_CloseOverlapped(
+        &Script,
+        &Overlapped,
+        ScriptedAbortPipe,
+        ScriptedGetOverlappedResult,
+        ScriptedReleaseOverlapped,
+        &Script,
+        ScriptedCloseTick,
+        ScriptedCloseSleep,
+        &fReleased));
+    ASSERT_FALSE(fReleased);
+    ASSERT_FALSE(Script.fRxAborted);
     ASSERT_EQ(Script.cReleaseCalls, 1);
 }
 
@@ -1713,6 +1778,8 @@ int main(void)
     RUN_TEST(TestOverlappedReadLifecycleAndCloseOrdering);
     RUN_TEST(TestClosePendingForeverIsBoundedAndDoesNotRelease);
     RUN_TEST(TestCloseReportsAbortErrorAfterAttemptingCleanup);
+    RUN_TEST(TestCloseUnexpectedQueryErrorStillAbortsAndReleases);
+    RUN_TEST(TestCloseReleaseFailureKeepsHandleOwnership);
     RUN_TEST(TestConfigurePipeTimeoutsConfiguresBothDirections);
     RUN_TEST(TestConfigurePipeTimeoutsReportsEitherFailure);
     RUN_TEST(TestRecoveryCoordinatorExecutesOneOrderedAttempt);


### PR DESCRIPTION
## Problem

`DeviceFPGA_Session_CloseOverlapped()` unconditionally aborted the RX pipe, waited for cancellation, and then released the `OVERLAPPED` object — regardless of whether that object had ever been submitted, and regardless of whether cancellation completed.

Two consequences follow. Closing an idle handle aborted and queried an object the driver had never been given. And when cancellation did not complete, the old code still called `FT_ReleaseOverlapped()` on an object the driver continued to own.

## Summary

- Query an overlapped read before aborting it, and release immediately when it has already completed.
- Abort only a genuinely pending read, wait for bounded cancellation, and never release an object whose cancellation did not complete.
- After an unexpected `GetOverlappedResult()` status, still attempt RX abort and bounded completion, preserving the previous recovery attempt.
- Track pending state for normal bounded reads, so recovery cannot mistake a timed-out operation for an idle object.
- Skip blanket RX/TX aborts when recovery closes an idle handle.
- Report release ownership separately from cleanup success via a new `pfOverlappedReleased` out-parameter. Callers keep the object handle-owned — flags set, storage intact — until release actually succeeds or `FT_Close()` has returned. `DeviceFPGA_FTDI_RecoveryQuiesce()` deliberately leaves that state intact when `FT_Close()` fails, so a later quiesce still takes the abort path.
- Count all executed session cases, including nested lifecycle subcases, instead of printing a hardcoded total.

## Defect reproduction, before and after

Built and tested on a Linux ARM64 host and a Windows 11 x64 host. Tested against a Windows 11 x64 target and a Linux x64 target. For the before-and-after comparison, the host, target, FPGA device, and first-chance exception recorder were held constant; only `leechcore.dll` changed.

| Hardware test | Before | After |
| --- | --- | --- |
| Fresh `CFGREGPCIE`, then close | Access violation captured inside `FTD3XXWU!FT_AbortPipe` on trial 6. | 500/500 sessions completed with no first-chance access violation and no close failure. |
| Fresh idle open, then close | Access violation captured inside `FTD3XXWU!FT_AbortPipe` on trial 27. | 500/500 sessions completed with no first-chance access violation and no close failure. |

The capture site corroborates the diagnosis: the fault is inside the abort call that this change stops issuing when no read is pending.

The pre-fix recorder halted on the first captured access violation, so trials 6 and 27 are time-to-first-capture observations, not failure-rate estimates.

## Validation

- Rebased onto current master.
- Windows x64 and Win32: LeechCore and all three test projects rebuild; the session suite reports 54 measured cases on each architecture; read-policy and scatter-contract suites pass.
- New regressions cover ownership retention, unexpected query status, cancellation timeout, abort error, and release failure.
- The final commit is formatting only, collapsing wrapped conditions in `device_fpga.c` to match surrounding style. It is token-identical to its parent and can be dropped if unwanted.

## Interaction with #89 and #90

#90 depends on this change and its branch currently contains these commits; it will shrink to its own commits once this merges. #89 is independent.

#89 and #91 now share the exact runner-only ancestor `6df9749` (`test(fpga): report executed session cases`); stacked #90 inherits it through this branch. Git simulations of all six landing permutations completed without conflicts and produced the same final tree (`1b7c1dc`). No rebase or manual test-runner resolution is needed in any order.

- Windows x64 and Win32: LeechCore and all three test projects rebuild on the composed tree; the combined session suite reports 87 measured cases on each architecture; read-policy and scatter-contract suites pass.
- Linux x86_64: read-policy tests, 5 FPGA session wait cases, and the inline framing code-generation check pass.
- ARM64 Linux: the same suites pass, and the combined shared library builds as an ELF64 AArch64 object.
- #90 remains intentionally stacked on this branch, so the configured review order is #91 then #90. #89 can land before, between, or after that stack.

## Additional hardware validation

This head is a direct ancestor of the stacked #90 head. That stack was tested on a Windows 11 x64 host against a Windows 11 x64 target and a Linux x64 target, covering the revised ownership and release behavior together with the dependent changes in #90. Device `fpga://ft601=1`.

- Ten alternating 512 MiB A/B pairs per variant: 131072/131072 pages per run, zero failed pages, zero timeouts, zero process failures.
- Mean terminal speed was 115 MiB/s for both master and candidate. Candidate mean elapsed time was 4512.5 ms versus 4688.3 ms, 3.75% lower. This pair is a no-regression check on the normal read path, not evidence for the defect above.
- The combined #89 + #90/#91 build completed 150 sustained and 150 fresh-process configuration-command invocations with zero open, close, timeout, process, or semantic failures.

Contribution offered under the 0BSD license.
